### PR TITLE
Implement Sync for SendValue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,6 +503,8 @@ impl<'s, T: Unpin> Future for SendValue<'s, T> {
     }
 }
 
+unsafe impl<'s, T> Sync for SendValue<'s, T> {}
+
 impl<'s, T> Drop for SendValue<'s, T> {
     fn drop(&mut self) {
         if let Some(waker_node) = unsafe { (*self.waker_node.get()).as_ref() } {

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -2,7 +2,7 @@
 
 #![feature(once_cell)]
 
-use inbox::{new_small, Manager, Receiver, RecvError, SendError, Sender};
+use inbox::{new_small, Manager, Receiver, RecvError, SendError, SendValue, Sender};
 
 mod util;
 
@@ -36,6 +36,16 @@ fn manager_is_send() {
 #[test]
 fn manager_is_sync() {
     assert_sync::<Manager<()>>();
+}
+
+#[test]
+fn send_value_is_send() {
+    assert_send::<SendValue<'_, ()>>();
+}
+
+#[test]
+fn send_value_is_sync() {
+    assert_sync::<SendValue<'_, ()>>();
 }
 
 #[test]


### PR DESCRIPTION
SendValue was `!Sync` due to the `UnsafeCell`, but the contents are atomic
and protected by a `Mutex`.