### PR TITLE
Channel capacity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ use std::marker::PhantomPinned;
 use std::mem::{size_of, MaybeUninit};
 use std::pin::Pin;
 use std::ptr::{self, NonNull};
-use std::sync::atomic::{fence, AtomicPtr, AtomicUsize, Ordering};
+use std::sync::atomic::{fence, AtomicPtr, AtomicU64, AtomicUsize, Ordering};
 use std::task::{self, Poll};
 
 use parking_lot::Mutex;
@@ -109,57 +109,57 @@ const fn has_manager(status: usize) -> bool {
 const SMALL_CAP: usize = 8;
 
 // Bits to mark the status of a slot.
-const STATUS_BITS: usize = 2; // Number of bits used per slot.
-const STATUS_MASK: usize = (1 << STATUS_BITS) - 1;
+const STATUS_BITS: u64 = 2; // Number of bits used per slot.
+const STATUS_MASK: u64 = (1 << STATUS_BITS) - 1;
 #[cfg(test)]
-const ALL_STATUSES_MASK: usize = (1 << (SMALL_CAP * STATUS_BITS)) - 1;
+const ALL_STATUSES_MASK: u64 = (1 << (SMALL_CAP as u64 * STATUS_BITS)) - 1;
 // The possible statuses of a slot.
-const EMPTY: usize = 0b00; // Slot is empty (initial state).
-const TAKEN: usize = 0b01; // `Sender` acquired write access, currently writing.
-const FILLED: usize = 0b11; // `Sender` wrote a value into the slot.
-const READING: usize = 0b10; // A `Receiver` is reading from the slot.
+const EMPTY: u64 = 0b00; // Slot is empty (initial state).
+const TAKEN: u64 = 0b01; // `Sender` acquired write access, currently writing.
+const FILLED: u64 = 0b11; // `Sender` wrote a value into the slot.
+const READING: u64 = 0b10; // A `Receiver` is reading from the slot.
 
 // Status transitions.
-const MARK_TAKEN: usize = 0b01; // OR to go from EMPTY -> TAKEN.
-const MARK_FILLED: usize = 0b11; // OR to go from TAKEN -> FILLED.
-const MARK_READING: usize = 0b01; // XOR to go from FILLED -> READING.
-const MARK_EMPTIED: usize = 0b11; // ! AND to go from FILLED or READING -> EMPTY.
+const MARK_TAKEN: u64 = 0b01; // OR to go from EMPTY -> TAKEN.
+const MARK_FILLED: u64 = 0b11; // OR to go from TAKEN -> FILLED.
+const MARK_READING: u64 = 0b01; // XOR to go from FILLED -> READING.
+const MARK_EMPTIED: u64 = 0b11; // ! AND to go from FILLED or READING -> EMPTY.
 
 /// Returns `true` if `slot` in `status` is empty.
 #[inline(always)]
-fn is_available(status: usize, slot: usize) -> bool {
+fn is_available(status: u64, slot: usize) -> bool {
     has_status(status, slot, EMPTY)
 }
 
 /// Returns `true` if `slot` in `status` is filled.
 #[inline(always)]
-fn is_filled(status: usize, slot: usize) -> bool {
+fn is_filled(status: u64, slot: usize) -> bool {
     has_status(status, slot, FILLED)
 }
 
 /// Returns `true` if `slot` (in `status`) equals the `expected` status.
 #[inline(always)]
-fn has_status(status: usize, slot: usize, expected: usize) -> bool {
+fn has_status(status: u64, slot: usize, expected: u64) -> bool {
     slot_status(status, slot) == expected
 }
 
 /// Returns the `STATUS_BITS` for `slot` in `status`.
 #[inline(always)]
-fn slot_status(status: usize, slot: usize) -> usize {
+fn slot_status(status: u64, slot: usize) -> u64 {
     debug_assert!(slot <= SMALL_CAP);
-    (status >> (STATUS_BITS * slot)) & STATUS_MASK
+    (status >> (STATUS_BITS * slot as u64)) & STATUS_MASK
 }
 
 /// Creates a mask to transition `slot` using `transition`. `transition` must be
 /// one of the `MARK_*` constants.
 #[inline(always)]
-fn mark_slot(slot: usize, transition: usize) -> usize {
+fn mark_slot(slot: usize, transition: u64) -> u64 {
     debug_assert!(slot <= SMALL_CAP);
-    transition << (STATUS_BITS * slot)
+    transition << (STATUS_BITS * slot as u64)
 }
 
 /// Returns a string name for the `slot_status`.
-fn dbg_status(slot_status: usize) -> &'static str {
+fn dbg_status(slot_status: u64) -> &'static str {
     match slot_status {
         EMPTY => "EMPTY",
         TAKEN => "TAKEN",
@@ -170,14 +170,14 @@ fn dbg_status(slot_status: usize) -> &'static str {
 }
 
 // Bits to mark the position of the receiver.
-const POS_BITS: usize = 3; // Must be `2 ^ POS_BITS == SMALL_CAP`.
-const POS_MASK: usize = (1 << POS_BITS) - 1;
-const MARK_NEXT_POS: usize = 1 << (STATUS_BITS * SMALL_CAP); // Add to increase position by 1.
+const POS_BITS: u64 = 3; // Must be `2 ^ POS_BITS == SMALL_CAP`.
+const POS_MASK: u64 = (1 << POS_BITS) - 1;
+const MARK_NEXT_POS: u64 = 1 << (STATUS_BITS * SMALL_CAP as u64); // Add to increase position by 1.
 
 /// Returns the position of the receiver. Will be in 0..SMALL_CAP range.
 #[inline(always)]
-fn receiver_pos(status: usize) -> usize {
-    status >> (STATUS_BITS * SMALL_CAP) & POS_MASK
+fn receiver_pos(status: u64) -> usize {
+    (status >> (STATUS_BITS * SMALL_CAP as u64) & POS_MASK) as usize
 }
 
 /// Sending side of the channel.
@@ -290,7 +290,7 @@ fn try_send<T>(channel: &Channel<T>, value: T) -> Result<(), SendError<T>> {
     // NOTE: relaxed ordering here is ok because we acquire unique
     // permission to write to the slot later before writing to it. Something
     // we have to do no matter the ordering.
-    let mut status: usize = channel.status.load(Ordering::Relaxed);
+    let mut status: u64 = channel.status.load(Ordering::Relaxed);
     let start = receiver_pos(status);
     for slot in (0..SMALL_CAP).cycle().skip(start).take(SMALL_CAP) {
         if !is_available(status, slot) {
@@ -825,7 +825,7 @@ struct Channel<T> {
     /// The first `STATUS_BITS * SMALL_CAP` bits are the statuses for the
     /// `slots` field. The remaining bits are used by the `Sender` to indicate
     /// its current reading position (modulo `SMALL_CAP`).
-    status: AtomicUsize,
+    status: AtomicU64,
     /// The slots in the channel, see `status` for what slots are used/unused.
     slots: [UnsafeCell<MaybeUninit<T>>; SMALL_CAP],
     /// The number of senders alive. If the [`RECEIVER_ALIVE`] bit is set the
@@ -866,7 +866,7 @@ impl<T> Channel<T> {
                 UnsafeCell::new(MaybeUninit::uninit()),
                 UnsafeCell::new(MaybeUninit::uninit()),
             ],
-            status: AtomicUsize::new(0),
+            status: AtomicU64::new(0),
             ref_count: AtomicUsize::new(RECEIVER_ALIVE | 1),
             sender_waker_head: AtomicPtr::new(ptr::null_mut()),
             receiver_waker: WakerRegistration::new(),
@@ -1052,7 +1052,7 @@ impl<T> Drop for Channel<T> {
     fn drop(&mut self) {
         // Safety: we have unique access, per the mutable reference, so relaxed
         // is fine.
-        let status: usize = self.status.load(Ordering::Relaxed);
+        let status: u64 = self.status.load(Ordering::Relaxed);
         for slot in 0..SMALL_CAP {
             if is_filled(status, slot) {
                 // Safety: we have unique access to the slot and it's properly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,6 @@
 //! receiver_handle.join().unwrap();
 //! ```
 
-// TODO: support larger channel, with more slots.
-
 #![feature(maybe_uninit_extra)]
 #![warn(
     missing_debug_implementations,
@@ -90,12 +88,28 @@ use waker::WakerRegistration;
 
 /// The capacity of a small channel.
 const SMALL_CAP: usize = 8;
-/// Maximum capacity of a channel, see [`Channel::new`].
-const MAX_CAP: usize = 29;
+/// Maximum capacity of a channel.
+// NOTE: see [`Channel::new`] why.
+pub const MAX_CAP: usize = 29;
+/// Minimum capacity of a channel.
+pub const MIN_CAP: usize = 1;
 
 /// Create a small bounded channel.
 pub fn new_small<T>() -> (Sender<T>, Receiver<T>) {
-    let channel = Channel::new(SMALL_CAP);
+    new(SMALL_CAP)
+}
+
+/// Create a new bounded channel.
+///
+/// The `capacity` must be in the range [`MIN_CAP`]`..=`[`MAX_CAP`].
+pub fn new<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
+    assert!(
+        (MIN_CAP..=MAX_CAP).contains(&capacity),
+        "inbox channel capacity must be between {} and {}",
+        MIN_CAP,
+        MAX_CAP
+    );
+    let channel = Channel::new(capacity);
     let sender = Sender { channel };
     let receiver = Receiver { channel };
     (sender, receiver)
@@ -174,14 +188,12 @@ fn dbg_status(slot_status: u64) -> &'static str {
 }
 
 // Bits to mark the position of the receiver.
-const POS_BITS: u64 = 6; // Must be `2 ^ POS_BITS >= MAX_CAP`.
-const POS_MASK: u64 = (1 << POS_BITS) - 1;
 const MARK_NEXT_POS: u64 = 1 << (STATUS_BITS * MAX_CAP as u64); // Add to increase position by 1.
 
-/// Returns the position of the receiver. Will be in 0..MAX_CAP range.
+/// Returns the position of the receiver. Will be in 0..[`MAX_CAP`] range.
 #[inline(always)]
 fn receiver_pos(status: u64, capacity: usize) -> usize {
-    (status >> (STATUS_BITS * MAX_CAP as u64) & POS_MASK) as usize % capacity
+    (status >> (STATUS_BITS * MAX_CAP as u64)) as usize % capacity
 }
 
 /// Sending side of the channel.
@@ -849,7 +861,7 @@ struct Inner {
     ///
     /// The first `STATUS_BITS * MAX_CAP` bits are the statuses for the `slots`
     /// field. The remaining bits are used by the `Sender` to indicate its
-    /// current reading position (modulo `MAX_CAP`).
+    /// current reading position (modulo [`MAX_CAP`]).
     status: AtomicU64,
 }
 
@@ -869,18 +881,19 @@ struct WakerList {
 impl<T> Channel<T> {
     /// Allocates a new `Channel` on the heap.
     ///
-    /// `length` must small enough to ensure each slot has 2 bits for the
-    /// status, while ensuring that the remaining bits can store `length` (in
+    /// `capacity` must small enough to ensure each slot has 2 bits for the
+    /// status, while ensuring that the remaining bits can store `capacity` (in
     /// binary) to keep track of the reading position. This means following must
-    /// hold true where $N is length: `2 ^ (64 - ($N * 2)) >= $N`. The maximum
+    /// hold true where $N is capacity: `2 ^ (64 - ($N * 2)) >= $N`. The maximum
     /// is 29.
-    fn new(length: usize) -> NonNull<Channel<T>> {
-        assert!(length <= MAX_CAP, "length too large");
+    fn new(capacity: usize) -> NonNull<Channel<T>> {
+        assert!(capacity != 0, "capacity can't be zero");
+        assert!(capacity <= MAX_CAP, "capacity too large");
 
         // Allocate some raw bytes.
         // Safety: returns an error on arithmetic overflow, but it should be OK
-        // with a length <= MAX_CAP.
-        let (layout, _) = Layout::array::<UnsafeCell<MaybeUninit<T>>>(length)
+        // with a capacity <= MAX_CAP.
+        let (layout, _) = Layout::array::<UnsafeCell<MaybeUninit<T>>>(capacity)
             .and_then(|slots_layout| Layout::new::<Inner>().extend(slots_layout))
             .unwrap();
         // Safety: we check if the allocation is successful.
@@ -888,7 +901,7 @@ impl<T> Channel<T> {
         if ptr.is_null() {
             handle_alloc_error(layout);
         }
-        let ptr = ptr::slice_from_raw_parts_mut(ptr as *mut T, length) as *mut Channel<T>;
+        let ptr = ptr::slice_from_raw_parts_mut(ptr as *mut T, capacity) as *mut Channel<T>;
 
         // Initialise all fields (that need it).
         unsafe {
@@ -1128,7 +1141,14 @@ impl<T> Manager<T> {
     ///
     /// Same as [`new_small`] but with a `Manager`.
     pub fn new_small_channel() -> (Manager<T>, Sender<T>, Receiver<T>) {
-        let (sender, receiver) = new_small();
+        Manager::new_channel(SMALL_CAP)
+    }
+
+    /// Create a bounded channel with a `Manager`.
+    ///
+    /// Same as [`new`] but with a `Manager`.
+    pub fn new_channel(capacity: usize) -> (Manager<T>, Sender<T>, Receiver<T>) {
+        let (sender, receiver) = new(capacity);
         let old_count = sender
             .channel()
             .ref_count

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1080,6 +1080,7 @@ impl<T> Deref for Channel<T> {
 impl<T> fmt::Debug for Channel<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let status = self.status.load(Ordering::Relaxed);
+        let recv_pos = receiver_pos(status, self.slots.len());
         let ref_count = self.ref_count.load(Ordering::Relaxed);
         let sender_count = ref_count & (!(RECEIVER_ALIVE | MANAGER_ALIVE));
         let mut slots = [""; MAX_CAP];
@@ -1091,6 +1092,7 @@ impl<T> fmt::Debug for Channel<T> {
             .field("senders_alive", &sender_count)
             .field("receiver_alive", &(ref_count & RECEIVER_ALIVE != 0))
             .field("manager_alive", &(ref_count & MANAGER_ALIVE != 0))
+            .field("receiver_position", &recv_pos)
             .field("slots", &slots)
             .finish()
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,7 +12,7 @@ use parking_lot::Mutex;
 use crate::{
     has_status, new_small, receiver_pos, slot_status, Channel, Inner, Manager, Receiver, SendValue,
     Sender, WakerList, ALL_STATUSES_MASK, EMPTY, FILLED, MARK_EMPTIED, MARK_NEXT_POS, MARK_READING,
-    MAX_CAP, POS_BITS, READING, SMALL_CAP, TAKEN,
+    READING, SMALL_CAP, TAKEN,
 };
 
 fn test_channel() -> Box<Channel<usize>> {
@@ -34,9 +34,6 @@ fn size_assertions() {
 fn assertions() {
     // Various assertions that must be true for the channel to work
     // correctly.
-
-    // Enough bits for the statuses of the slots.
-    assert!(2_usize.pow(POS_BITS as u32) >= MAX_CAP);
 
     // Status are different.
     assert_ne!(EMPTY, TAKEN);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -49,12 +49,12 @@ fn assertions() {
     assert_eq!(READING & !MARK_EMPTIED, EMPTY);
 
     // Changing `Receiver` position doesn't change status of slots.
-    const ORIGINAL_STATUS: usize = 0b1110010011100100;
+    const ORIGINAL_STATUS: u64 = 0b1110010011100100;
     assert_eq!(
         (size_of::<usize>() * 8) - (ORIGINAL_STATUS.leading_zeros() as usize),
         2 * SMALL_CAP
     );
-    let mut status: usize = ORIGINAL_STATUS.wrapping_sub(MARK_NEXT_POS);
+    let mut status: u64 = ORIGINAL_STATUS.wrapping_sub(MARK_NEXT_POS);
     status = status.wrapping_add(MARK_NEXT_POS);
     assert_eq!(status, ORIGINAL_STATUS);
     status = status.wrapping_add(MARK_NEXT_POS);

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -2,443 +2,498 @@
 
 #![feature(once_cell)]
 
-use inbox::{new_small, Manager};
+use inbox::{new, Manager};
 
 #[macro_use]
 mod util;
 
-use util::{DropTest, IsDropped, NeverDrop, SMALL_CAP};
+use util::{DropTest, IsDropped, NeverDrop};
 
 #[test]
 fn empty() {
-    let (sender, receiver) = new_small::<NeverDrop>();
-    drop(sender);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<NeverDrop>(capacity);
+        drop(sender);
+        drop(receiver);
 
-    let (sender, receiver) = new_small::<NeverDrop>();
-    drop(sender);
-    drop(receiver);
+        let (sender, receiver) = new::<NeverDrop>(capacity);
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn empty_cloned() {
-    let (sender, receiver) = new_small::<NeverDrop>();
-    let sender2 = sender.clone();
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<NeverDrop>(capacity);
+        let sender2 = sender.clone();
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
 
-    let (sender, receiver) = new_small::<NeverDrop>();
-    let sender2 = sender.clone();
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
+        let (sender, receiver) = new::<NeverDrop>(capacity);
+        let sender2 = sender.clone();
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn empty_with_manager() {
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    drop(sender);
-    drop(receiver);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        drop(sender);
+        drop(receiver);
+        drop(manager);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    drop(sender);
-    drop(receiver);
-    drop(manager);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        drop(sender);
+        drop(receiver);
+        drop(manager);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    drop(manager);
-    drop(sender);
-    drop(receiver);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        drop(manager);
+        drop(sender);
+        drop(receiver);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    drop(manager);
-    drop(sender);
-    drop(receiver);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        drop(manager);
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn empty_cloned_with_manager() {
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    let sender2 = sender.clone();
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        let sender2 = sender.clone();
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
+        drop(manager);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    let sender2 = sender.clone();
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
-    drop(manager);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        let sender2 = sender.clone();
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
+        drop(manager);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    let sender2 = sender.clone();
-    drop(manager);
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        let sender2 = sender.clone();
+        drop(manager);
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    let sender2 = sender.clone();
-    drop(manager);
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        let sender2 = sender.clone();
+        drop(manager);
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn send_single_value_sr() {
-    let (sender, receiver) = new_small();
-    let (value, _check) = DropTest::new();
-    sender.try_send(value).unwrap();
-    drop(sender);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let (value, _check) = DropTest::new();
+        sender.try_send(value).unwrap();
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn send_single_value_rs() {
-    let (sender, receiver) = new_small();
-    let (value, _check) = DropTest::new();
-    sender.try_send(value).unwrap();
-    drop(receiver);
-    drop(sender);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let (value, _check) = DropTest::new();
+        sender.try_send(value).unwrap();
+        drop(receiver);
+        drop(sender);
+    });
 }
 
 #[test]
 fn send_single_value_with_manager() {
-    let (manager, sender, receiver) = Manager::new_small_channel();
-    let (value, _check) = DropTest::new();
-    sender.try_send(value).unwrap();
-    drop(sender);
-    drop(receiver);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, receiver) = Manager::new_channel(capacity);
+        let (value, _check) = DropTest::new();
+        sender.try_send(value).unwrap();
+        drop(sender);
+        drop(receiver);
+        drop(manager);
+    });
 }
 
 #[test]
 fn full_channel_sr() {
-    let (sender, receiver) = new_small();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    drop(sender);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn full_channel_rs() {
-    let (sender, receiver) = new_small();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    drop(receiver);
-    drop(sender);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        drop(receiver);
+        drop(sender);
+    });
 }
 
 #[test]
 fn full_channel_with_manager() {
-    let (manager, sender, receiver) = Manager::new_small_channel();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    drop(sender);
-    drop(receiver);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, receiver) = Manager::new_channel(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        drop(sender);
+        drop(receiver);
+        drop(manager);
+    });
 }
 
 #[test]
 fn value_received_sr() {
-    let (sender, mut receiver) = new_small();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    let _value1 = receiver.try_recv().unwrap();
-    let _value2 = receiver.try_recv().unwrap();
-    drop(sender);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        let _value1 = receiver.try_recv().unwrap();
+        if capacity > 1 {
+            let _value2 = receiver.try_recv().unwrap();
+        }
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn value_received_rs() {
-    let (sender, mut receiver) = new_small();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    let _value1 = receiver.try_recv().unwrap();
-    let _value2 = receiver.try_recv().unwrap();
-    drop(receiver);
-    drop(sender);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        let _value1 = receiver.try_recv().unwrap();
+        if capacity > 1 {
+            let _value2 = receiver.try_recv().unwrap();
+        }
+        drop(receiver);
+        drop(sender);
+    });
 }
 
 #[test]
 fn value_received_with_manager() {
-    let (manager, sender, mut receiver) = Manager::new_small_channel();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    let _value1 = receiver.try_recv().unwrap();
-    let _value2 = receiver.try_recv().unwrap();
-    drop(receiver);
-    drop(sender);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, mut receiver) = Manager::new_channel(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        let _value1 = receiver.try_recv().unwrap();
+        if capacity > 1 {
+            let _value2 = receiver.try_recv().unwrap();
+        }
+        drop(receiver);
+        drop(sender);
+        drop(manager);
+    });
 }
 
 mod threaded {
+    use std::cmp::min;
     use std::thread;
     use std::time::Duration;
 
-    use inbox::{new_small, Manager};
+    use inbox::{new, Manager};
 
-    use super::{DropTest, NeverDrop, SMALL_CAP};
+    use crate::util::{DropTest, NeverDrop};
 
     #[test]
     fn empty() {
-        let (sender, receiver) = new_small::<NeverDrop>();
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new::<NeverDrop>(capacity);
 
-        start_threads!(
-            {
-                drop(sender);
-            },
-            {
-                drop(receiver);
-            }
-        );
+            start_threads!(
+                {
+                    drop(sender);
+                },
+                {
+                    drop(receiver);
+                }
+            );
+        })
     }
 
     #[test]
     fn empty_cloned() {
-        let (sender, receiver) = new_small::<NeverDrop>();
-        let sender2 = sender.clone();
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new::<NeverDrop>(capacity);
+            let sender2 = sender.clone();
 
-        start_threads!(
-            {
-                drop(sender);
-            },
-            {
-                drop(sender2);
-            },
-            {
-                drop(receiver);
-            }
-        );
+            start_threads!(
+                {
+                    drop(sender);
+                },
+                {
+                    drop(sender2);
+                },
+                {
+                    drop(receiver);
+                }
+            );
+        });
     }
 
     #[test]
     fn empty_with_manager() {
-        let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
+        with_all_capacities!(|capacity| {
+            let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
 
-        start_threads!(
-            {
-                drop(sender);
-            },
-            {
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            },
-        );
+            start_threads!(
+                {
+                    drop(sender);
+                },
+                {
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
+                },
+            );
+        });
     }
 
     #[test]
     fn empty_cloned_with_manager() {
-        let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-        let sender2 = sender.clone();
+        with_all_capacities!(|capacity| {
+            let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+            let sender2 = sender.clone();
 
-        start_threads!(
-            {
-                drop(sender);
-            },
-            {
-                drop(sender2);
-            },
-            {
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            },
-        );
+            start_threads!(
+                {
+                    drop(sender);
+                },
+                {
+                    drop(sender2);
+                },
+                {
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
+                },
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn send_single_value() {
-        let (sender, receiver) = new_small();
-        let (value, _check) = DropTest::new();
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new(capacity);
+            let (value, _check) = DropTest::new();
 
-        start_threads!(
-            {
-                expect_send!(sender, value);
-                drop(sender);
-            },
-            {
-                // Give the sender a chance to send the message.
-                thread::sleep(Duration::from_millis(10));
-                drop(receiver);
-            }
-        );
+            start_threads!(
+                {
+                    expect_send!(sender, value);
+                    drop(sender);
+                },
+                {
+                    // Give the sender a chance to send the message.
+                    thread::sleep(Duration::from_millis(10));
+                    drop(receiver);
+                }
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn send_single_value_with_manager() {
-        let (manager, sender, receiver) = Manager::new_small_channel();
-        let (value, _check) = DropTest::new();
+        with_all_capacities!(|capacity| {
+            let (manager, sender, receiver) = Manager::new_channel(capacity);
+            let (value, _check) = DropTest::new();
 
-        start_threads!(
-            {
-                expect_send!(sender, value);
-                drop(sender);
-            },
-            {
-                // Give the sender a chance to send the message.
-                thread::sleep(Duration::from_millis(10));
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            },
-        );
+            start_threads!(
+                {
+                    expect_send!(sender, value);
+                    drop(sender);
+                },
+                {
+                    // Give the sender a chance to send the message.
+                    thread::sleep(Duration::from_millis(10));
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
+                },
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn full_channel() {
-        let (sender, receiver) = new_small();
-        let (values, _checks) = DropTest::many(SMALL_CAP);
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new(capacity);
+            let (values, _checks) = DropTest::many(capacity);
 
-        start_threads!(
-            {
-                for value in values {
-                    expect_send!(sender, value);
+            start_threads!(
+                {
+                    for value in values {
+                        expect_send!(sender, value);
+                    }
+                    drop(sender);
+                },
+                {
+                    // Give the sender a chance to send the messages.
+                    thread::sleep(Duration::from_millis(200));
+                    drop(receiver);
                 }
-                drop(sender);
-            },
-            {
-                // Give the sender a chance to send the messages.
-                thread::sleep(Duration::from_millis(200));
-                drop(receiver);
-            }
-        );
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn full_channel_with_manager() {
-        let (manager, sender, receiver) = Manager::new_small_channel();
-        let (values, _checks) = DropTest::many(SMALL_CAP);
+        with_all_capacities!(|capacity| {
+            let (manager, sender, receiver) = Manager::new_channel(capacity);
+            let (values, _checks) = DropTest::many(capacity);
 
-        start_threads!(
-            {
-                for value in values {
-                    expect_send!(sender, value);
-                }
-                drop(sender);
-            },
-            {
-                // Give the sender a chance to send the messages.
-                thread::sleep(Duration::from_millis(200));
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            },
-        );
+            start_threads!(
+                {
+                    for value in values {
+                        expect_send!(sender, value);
+                    }
+                    drop(sender);
+                },
+                {
+                    // Give the sender a chance to send the messages.
+                    thread::sleep(Duration::from_millis(200));
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
+                },
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn value_received() {
-        let (sender, mut receiver) = new_small();
-        let (values, _checks) = DropTest::many(SMALL_CAP);
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new(capacity);
+            let (values, _checks) = DropTest::many(capacity);
 
-        start_threads!(
-            {
-                for value in values {
-                    expect_send!(sender, value);
-                }
-                drop(sender);
-            },
-            {
-                for _ in 0..2 {
-                    r#loop! {
-                        match receiver.try_recv() {
-                            Ok(..) => break,
-                            Err(inbox::RecvError::Empty) => {} // Try again.
-                            Err(err) => panic!("unexpected error receiving: {}", err),
+            start_threads!(
+                {
+                    for value in values {
+                        expect_send!(sender, value);
+                    }
+                    drop(sender);
+                },
+                {
+                    let receive_max = min(2, capacity);
+                    for _ in 0..receive_max {
+                        r#loop! {
+                            match receiver.try_recv() {
+                                Ok(..) => break,
+                                Err(inbox::RecvError::Empty) => {} // Try again.
+                                Err(err) => panic!("unexpected error receiving: {}", err),
+                            }
                         }
                     }
+                    // Give the sender a chance to send the remaining messages.
+                    thread::sleep(Duration::from_millis(200));
+                    drop(receiver);
                 }
-                // Give the sender a chance to send the remaining messages.
-                thread::sleep(Duration::from_millis(200));
-                drop(receiver);
-            }
-        );
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn value_received_with_manager() {
-        let (manager, sender, mut receiver) = Manager::new_small_channel();
-        let (values, _checks) = DropTest::many(SMALL_CAP);
+        with_all_capacities!(|capacity| {
+            let (manager, sender, mut receiver) = Manager::new_channel(capacity);
+            let (values, _checks) = DropTest::many(capacity);
 
-        start_threads!(
-            {
-                for value in values {
-                    expect_send!(sender, value);
-                }
-                drop(sender);
-            },
-            {
-                for _ in 0..2 {
-                    r#loop! {
-                        match receiver.try_recv() {
-                            Ok(..) => break,
-                            Err(inbox::RecvError::Empty) => {} // Try again.
-                            Err(err) => panic!("unexpected error receiving: {}", err),
+            start_threads!(
+                {
+                    for value in values {
+                        expect_send!(sender, value);
+                    }
+                    drop(sender);
+                },
+                {
+                    let receive_max = min(2, capacity);
+                    for _ in 0..receive_max {
+                        r#loop! {
+                            match receiver.try_recv() {
+                                Ok(..) => break,
+                                Err(inbox::RecvError::Empty) => {} // Try again.
+                                Err(err) => panic!("unexpected error receiving: {}", err),
+                            }
                         }
                     }
+                    // Give the sender a chance to send the remaining messages.
+                    thread::sleep(Duration::from_millis(200));
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
                 }
-                // Give the sender a chance to send the remaining messages.
-                thread::sleep(Duration::from_millis(200));
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            }
-        );
+            );
+        });
     }
 }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -2,7 +2,7 @@
 
 #![feature(once_cell)]
 
-use inbox::{new_small, Manager, Receiver, RecvError, SendError, SendValue, Sender};
+use inbox::{new_small, Manager, Receiver, RecvError, SendError, SendValue, Sender, MAX_CAP};
 
 mod util;
 
@@ -49,10 +49,24 @@ fn send_value_is_sync() {
 }
 
 #[test]
+#[should_panic = "inbox channel capacity must be between 1 and 29"]
+fn capacity_of_zero_should_panic() {
+    let _ = inbox::new::<()>(0);
+}
+
+#[test]
+#[should_panic = "inbox channel capacity must be between 1 and 29"]
+fn capacity_too_large_should_panic() {
+    let _ = inbox::new::<()>(MAX_CAP + 1);
+}
+
+#[test]
 fn capacities_are_correct() {
-    let (sender, receiver) = new_small::<()>();
-    assert_eq!(sender.capacity(), SMALL_CAP);
-    assert_eq!(receiver.capacity(), SMALL_CAP);
+    for capacity in 1..MAX_CAP {
+        let (sender, receiver) = inbox::new::<()>(capacity);
+        assert_eq!(sender.capacity(), capacity);
+        assert_eq!(receiver.capacity(), capacity);
+    }
 }
 
 #[test]

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,28 +1,35 @@
 //! Regression tests.
 
-use inbox::new_small;
+#![feature(once_cell)]
+
+use inbox::new;
 use inbox::oneshot::{self, new_oneshot};
+
+#[macro_use]
+mod util;
 
 #[test]
 fn cyclic_drop_dependency_with_oneshot_channel() {
-    let (sender, receiver) = new_small();
-    let (one_send, mut one_recv) = new_oneshot::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let (one_send, mut one_recv) = new_oneshot::<usize>();
 
-    // Put `oneshot::Sender` in the channel.
-    sender.try_send(one_send).unwrap();
+        // Put `oneshot::Sender` in the channel.
+        sender.try_send(one_send).unwrap();
 
-    // Dropping the receiver should also drop the `oneshot::Sender` we send
-    // above.
-    drop(receiver);
-    // This needs to work in case we would call `oneshot::Receiver::recv` here.
-    // If we didn't empty the channel on dropping the `Receiver` this would
-    // return a `NoValue` error.
-    assert_eq!(
-        one_recv.try_recv().unwrap_err(),
-        oneshot::RecvError::Disconnected
-    );
+        // Dropping the receiver should also drop the `oneshot::Sender` we send
+        // above.
+        drop(receiver);
+        // This needs to work in case we would call `oneshot::Receiver::recv` here.
+        // If we didn't empty the channel on dropping the `Receiver` this would
+        // return a `NoValue` error.
+        assert_eq!(
+            one_recv.try_recv().unwrap_err(),
+            oneshot::RecvError::Disconnected
+        );
 
-    drop(one_recv);
-    // This needs to live until now.
-    drop(sender);
+        drop(one_recv);
+        // This needs to live until now.
+        drop(sender);
+    });
 }

--- a/tests/threaded.rs
+++ b/tests/threaded.rs
@@ -5,7 +5,7 @@
 use std::thread;
 use std::time::Duration;
 
-use inbox::{new_small, RecvError, SendError};
+use inbox::{new, RecvError, SendError};
 
 #[macro_use]
 mod util;
@@ -13,109 +13,121 @@ mod util;
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't finish.
 fn send_single_value() {
-    let (sender, mut receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            expect_send!(sender, 1);
-        },
-        {
-            expect_recv!(receiver, 1);
-        }
-    );
+        start_threads!(
+            {
+                expect_send!(sender, 1);
+            },
+            {
+                expect_recv!(receiver, 1);
+            }
+        );
+    });
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't finish.
 fn zero_sized_types() {
-    let (sender, mut receiver) = new_small();
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new(capacity);
 
-    start_threads!(
-        {
-            expect_send!(sender, ());
-        },
-        {
-            expect_recv!(receiver, ());
-        }
-    );
+        start_threads!(
+            {
+                expect_send!(sender, ());
+            },
+            {
+                expect_recv!(receiver, ());
+            }
+        );
+    });
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't finish.
 fn receive_no_sender() {
-    let (sender, mut receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            drop(sender);
-        },
-        {
-            r#loop! {
-                match receiver.try_recv() {
-                    Ok(..) => panic!("unexpected receive of value"),
-                    Err(RecvError::Empty) => {} // Try again.
-                    Err(RecvError::Disconnected) => break,
+        start_threads!(
+            {
+                drop(sender);
+            },
+            {
+                r#loop! {
+                    match receiver.try_recv() {
+                        Ok(..) => panic!("unexpected receive of value"),
+                        Err(RecvError::Empty) => {} // Try again.
+                        Err(RecvError::Disconnected) => break,
+                    }
                 }
             }
-        }
-    );
+        );
+    });
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't support `sleep`.
 fn send_no_receiver() {
-    let (sender, receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            thread::sleep(Duration::from_millis(1));
-            r#loop! {
-                match sender.try_send(1) {
-                    Ok(()) => {} // Try again.
-                    Err(SendError::Full(..)) => panic!("too slow!"),
-                    Err(SendError::Disconnected(..)) => break,
+        start_threads!(
+            {
+                thread::sleep(Duration::from_millis(1));
+                r#loop! {
+                    match sender.try_send(1) {
+                        Ok(()) => {} // Try again.
+                        Err(SendError::Full(..)) => panic!("too slow!"),
+                        Err(SendError::Disconnected(..)) => break,
+                    }
                 }
+            },
+            {
+                drop(receiver);
             }
-        },
-        {
-            drop(receiver);
-        }
-    );
+        );
+    });
 }
 
 #[test]
 fn sender_is_connected() {
-    let (sender, receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            r#loop! {
-                if !sender.is_connected() {
-                    break;
+        start_threads!(
+            {
+                r#loop! {
+                    if !sender.is_connected() {
+                        break;
+                    }
                 }
+            },
+            {
+                drop(receiver);
             }
-        },
-        {
-            drop(receiver);
-        }
-    );
+        );
+    });
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't finish.
 fn receiver_is_connected() {
-    let (sender, receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            drop(sender);
-        },
-        {
-            r#loop! {
-                if !receiver.is_connected() {
-                    break;
+        start_threads!(
+            {
+                drop(sender);
+            },
+            {
+                r#loop! {
+                    if !receiver.is_connected() {
+                        break;
+                    }
                 }
             }
-        }
-    );
+        );
+    });
 }


### PR DESCRIPTION
TODO:
* [x] Needs tests with all the possible capacities.
* [x] Benchmarks vs. the old implementation.

Change Channel's slot to be a slice

Allocating the Channel becomes a bit more complex as we need to manually
the layout for it and can't use the convenience of the Box type.

This also has the size effect of making the pointers in Sender, Receiver
and Manager a "fat" pointer. This means it will contain the regular
pointer and a length attribute, taking up (2 x 8) 16 bytes on 64bit.

This increases the size of Sender, Receiver, Manager from 8 to 16
bytes, and SendValue from 56 to 64 bytes.

If this size increase becomes a problem, or if we ever want to decrease
the memory usage we can change the fat pointer into a regular pointer
again and using some bits to indicate the length of the channel. For
examples if we have four different capacities, it can be encoded into
just 2 bits. These two bits can ORed with the regular pointer and be
received later.

The upside of such an approach would be that the size is reduced from 16
to 8 bytes. The downside is that on each access to the channel the
reference has to be prepared by unpacking the length from the pointer.
And ensuring the length is correct at all times is an additional
maintenance burden.


Add `new` function

Allows the creation of an user specified capacity bounded channel. The
current implementation is limited to a capacity in the range 1..=29.

This limitation is because of the size of the `status` in the Channel.
As each slot needs two bits for its status and we need enough bits for
the receiver position the current limit is 29. The following must hold
true, where $n is the capacity of the channel:
2 ^ (64 - ($N * 2)) >= $N.

Changes channel status to an `AtomicU64`.

Closes #4.
