### PR TITLE
Fix data race when dropping Sender/Receiver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1196,8 +1196,11 @@ impl<T> Drop for Manager<T> {
             return;
         }
 
-        let old_ref_count = self.channel().ref_count.fetch_or(RECEIVER_ALIVE, Ordering::AcqRel);
         debug_assert!(!has_receiver(old_ref_count));
+        debug_assert!(old_ref_count & RECEIVER_ACCESS != 0);
+        // NOTE: because `RECEIVER_ACCESS` bit is still set we don't have to set
+        // the `RECEIVER_ALIVE` bit (as the receiver will dropped at the end of
+        // the function).
         let receiver = Receiver { channel: self.channel };
 
         let _ = self.channel().ref_count.fetch_and(!MANAGER_ACCESS, Ordering::Release);


### PR DESCRIPTION
Before this patch in the `Drop` implementation for `Sender` would access
the channel to wake the receiver, by calling `Channel::wake_receiver`.
However it's possible for the `Receiver` to be dropped in between the
time the sender marks itself as dropped and the call to `wake_receiver`.
If this happens the `Channel` would be deallocated and the `Drop` impl
for `Sender` would access memory it doesn't own, which is of course
undefined behaviour.

A similar data race exists for the `Drop` impl for `Receiver`, when it
drops the messages by calling `self.try_recv` in a loop.

To fix this data race three bits are added,
{RECEIVER,SENDER,MANAGER}_ACCESS, which indicate if a
`Receiver`/`Sender`/`Manager` still has access to the channel and thus
can't be deallocated. With these bits still being set the other types
know not to deallocate the channel.

This means two atomic operations have to be done when dropping, an
increase from one previously. First, change the alive bit (unset it or
decrease the count for the Sender). Second, unset the access bit for the
type (only done for the last Sender).

This reduces the maximum number of Senders from 2 ^ 62 to 2 ^ 59 (on 64
bit), still plenty.

This is a similar design as found to the in the `Arc` type in standard
library (`std::sync::Arc`). There it increases the weak count by 1,
which has the same effect.
