### PR TITLE
Rename crate to heph-inbox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
-name          = "inbox"
-description   = "Bounded capacity channel designed to be used as inbox for actors."
+name          = "heph-inbox"
+description   = """
+Bounded capacity channel designed to be used as inbox for actors. Also supports
+one shot channels.
+"""
 version       = "0.1.0"
 authors       = ["Thomas de Zeeuw <thomasdezeeuw@gmail.com>"]
 license       = "MIT"
-documentation = "https://docs.rs/inbox"
+documentation = "https://docs.rs/heph-inbox"
 repository    = "https://github.com/Thomasdezeeuw/inbox"
 readme        = "README.md"
 keywords      = ["inbox", "channel", "actor", "async"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Inbox
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Crates.io](https://img.shields.io/crates/v/inbox.svg)](https://crates.io/crates/inbox)
-[![Docs](https://docs.rs/inbox/badge.svg)](https://docs.rs/inbox)
+[![Crates.io](https://img.shields.io/crates/v/heph-inbox.svg)](https://crates.io/crates/heph-inbox)
+[![Docs](https://docs.rs/heph-inbox/badge.svg)](https://docs.rs/heph-inbox)
 
 Bounded capacity channel.
 
@@ -18,10 +18,10 @@ Simple creation of a channel and sending a message over it.
 ```rust
 use std::thread;
 
-use inbox::RecvError;
+use heph_inbox::RecvError;
 
 // Create a new small channel.
-let (mut sender, mut receiver) = inbox::new_small();
+let (mut sender, mut receiver) = heph_inbox::new_small();
 
 let sender_handle = thread::spawn(move || {
     if let Err(err) = sender.try_send("Hello world!".to_owned()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@
 //! ```
 //! use std::thread;
 //!
-//! use inbox::RecvError;
+//! use heph_inbox::RecvError;
 //!
 //! // Create a new small channel.
-//! let (sender, mut receiver) = inbox::new_small();
+//! let (sender, mut receiver) = heph_inbox::new_small();
 //!
 //! let sender_handle = thread::spawn(move || {
 //!     if let Err(err) = sender.try_send("Hello world!".to_owned()) {

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -14,7 +14,7 @@
 //! ```
 //! use std::thread;
 //!
-//! use inbox::oneshot::{RecvError, new_oneshot};
+//! use heph_inbox::oneshot::{RecvError, new_oneshot};
 //!
 //! // Create a new small channel.
 //! let (sender, mut receiver) = new_oneshot();

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -2,7 +2,7 @@
 
 #![feature(once_cell)]
 
-use inbox::{new_small, Manager};
+use heph_inbox::{new_small, Manager};
 
 #[macro_use]
 mod util;
@@ -219,7 +219,7 @@ mod threaded {
     use std::thread;
     use std::time::Duration;
 
-    use inbox::{new_small, Manager};
+    use heph_inbox::{new_small, Manager};
 
     use super::{DropTest, NeverDrop, SMALL_CAP};
 
@@ -397,7 +397,7 @@ mod threaded {
                     r#loop! {
                         match receiver.try_recv() {
                             Ok(..) => break,
-                            Err(inbox::RecvError::Empty) => {} // Try again.
+                            Err(heph_inbox::RecvError::Empty) => {} // Try again.
                             Err(err) => panic!("unexpected error receiving: {}", err),
                         }
                     }
@@ -427,7 +427,7 @@ mod threaded {
                     r#loop! {
                         match receiver.try_recv() {
                             Ok(..) => break,
-                            Err(inbox::RecvError::Empty) => {} // Try again.
+                            Err(heph_inbox::RecvError::Empty) => {} // Try again.
                             Err(err) => panic!("unexpected error receiving: {}", err),
                         }
                     }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -2,7 +2,7 @@
 
 #![feature(once_cell)]
 
-use inbox::{new_small, Manager, Receiver, RecvError, SendError, SendValue, Sender};
+use heph_inbox::{new_small, Manager, Receiver, RecvError, SendError, SendValue, Sender};
 
 mod util;
 
@@ -310,7 +310,7 @@ mod future {
 
     use futures_test::task::{new_count_waker, AwokenCount};
 
-    use inbox::{new_small, Sender};
+    use heph_inbox::{new_small, Sender};
 
     use super::SMALL_CAP;
 
@@ -758,7 +758,7 @@ mod future {
 }
 
 mod manager {
-    use inbox::{Manager, ReceiverConnected};
+    use heph_inbox::{Manager, ReceiverConnected};
 
     #[test]
     fn new_sender() {

--- a/tests/oneshot.rs
+++ b/tests/oneshot.rs
@@ -6,7 +6,7 @@
 mod util;
 
 mod functional {
-    use inbox::oneshot::{new_oneshot, Receiver, RecvError, Sender};
+    use heph_inbox::oneshot::{new_oneshot, Receiver, RecvError, Sender};
 
     use crate::util::{assert_send, assert_sync};
 
@@ -102,7 +102,7 @@ mod future {
 
     use futures_test::task::new_count_waker;
 
-    use inbox::oneshot::new_oneshot;
+    use heph_inbox::oneshot::new_oneshot;
 
     macro_rules! pin_stack {
         ($fut: ident) => {
@@ -254,7 +254,7 @@ mod future {
 }
 
 mod drop {
-    use inbox::oneshot::new_oneshot;
+    use heph_inbox::oneshot::new_oneshot;
 
     use crate::util::{DropTest, NeverDrop};
 
@@ -351,7 +351,7 @@ mod drop {
         use std::thread;
         use std::time::Duration;
 
-        use inbox::oneshot::new_oneshot;
+        use heph_inbox::oneshot::new_oneshot;
 
         use crate::util::{DropTest, NeverDrop};
 
@@ -524,7 +524,7 @@ mod drop {
 }
 
 mod threaded {
-    use inbox::oneshot::{new_oneshot, RecvError};
+    use heph_inbox::oneshot::{new_oneshot, RecvError};
 
     /// Loop until a value is received.
     macro_rules! expect_recv {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,7 +1,7 @@
 //! Regression tests.
 
-use inbox::new_small;
-use inbox::oneshot::{self, new_oneshot};
+use heph_inbox::new_small;
+use heph_inbox::oneshot::{self, new_oneshot};
 
 #[test]
 fn cyclic_drop_dependency_with_oneshot_channel() {

--- a/tests/threaded.rs
+++ b/tests/threaded.rs
@@ -5,7 +5,7 @@
 use std::thread;
 use std::time::Duration;
 
-use inbox::{new_small, RecvError, SendError};
+use heph_inbox::{new_small, RecvError, SendError};
 
 #[macro_use]
 mod util;

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -145,7 +145,7 @@ macro_rules! expect_send {
         r#loop! {
             match $sender.try_send(value) {
                 Ok(()) => break,
-                Err(inbox::SendError::Full(v)) => {
+                Err(heph_inbox::SendError::Full(v)) => {
                     // Try again.
                     value = v;
                 },
@@ -164,7 +164,7 @@ macro_rules! expect_recv {
                     assert_eq!(msg, $expected);
                     break;
                 }
-                Err(inbox::RecvError::Empty) => {} // Try again.
+                Err(heph_inbox::RecvError::Empty) => {} // Try again.
                 Err(err) => panic!("unexpected error receiving: {}", err),
             }
         }


### PR DESCRIPTION
The inbox name is already taken.

I though I could come up with a good name before publish this, but nope.