### PR TITLE
Fix example when run under Miri

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! Simple creation of a channel and sending a message over it.
 //!
-//! ```
+//!```
 //! use std::thread;
 //!
 //! use heph_inbox::RecvError;
@@ -35,7 +35,8 @@
 //! });
 //!
 //! let receiver_handle = thread::spawn(move || {
-//!     # thread::sleep(std::time::Duration::from_millis(1)); // Don't waste cycles.
+//! #   #[cfg(not(miri))] // `sleep` not supported.
+//! #   thread::sleep(std::time::Duration::from_millis(1)); // Don't waste cycles.
 //!     // NOTE: this is just an example don't actually use a loop like this, it
 //!     // will waste CPU cycles when the channel is empty!
 //!     loop {

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -26,7 +26,8 @@
 //! });
 //!
 //! let receiver_handle = thread::spawn(move || {
-//!     # thread::sleep(std::time::Duration::from_millis(1)); // Don't waste cycles.
+//! #   #[cfg(not(miri))] // `sleep` not supported.
+//! #   thread::sleep(std::time::Duration::from_millis(1)); // Don't waste cycles.
 //!     // NOTE: this is just an example don't actually use a loop like this, it
 //!     // will waste CPU cycles when the channel is empty!
 //!     loop {


### PR DESCRIPTION
Miri doesn't support `thread::sleep` with disabling isolation (via
-Zmiri-disable-isolation).