### PR TITLE
Read message before changing status in oneshot::Receiver::try_recv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ const MANAGER_ALIVE: usize = 1 << (size_of::<usize>() * 8 - 4);
 /// for [`Manager`].
 const MANAGER_ACCESS: usize = 1 << (size_of::<usize>() * 8 - 5);
 
-/// Return `true` if the receiver or manager is alive in `ref_count.
+/// Return `true` if the receiver or manager is alive in `ref_count`.
 #[inline(always)]
 const fn has_receiver(ref_count: usize) -> bool {
     ref_count & RECEIVER_ALIVE != 0
@@ -134,7 +134,7 @@ const fn has_manager(ref_count: usize) -> bool {
     ref_count & MANAGER_ALIVE != 0
 }
 
-/// Return `true` if the receiver or manager is alive in `ref_count.
+/// Return `true` if the receiver or manager is alive in `ref_count`.
 #[inline(always)]
 const fn has_receiver_or_manager(ref_count: usize) -> bool {
     ref_count & (RECEIVER_ALIVE | MANAGER_ALIVE) != 0

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -46,7 +46,7 @@
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::future::Future;
-use std::mem::{size_of, MaybeUninit};
+use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -61,15 +61,15 @@ pub fn new_oneshot<T>() -> (Sender<T>, Receiver<T>) {
 }
 
 /// Bits mask to mark the receiver as alive.
-const RECEIVER_ALIVE: u8 = 1 << (size_of::<u8>() * 8 - 1);
+const RECEIVER_ALIVE: u8 = 0b1000_0000;
 /// Bit mask to mark the sender as alive.
-const SENDER_ALIVE: u8 = 1 << (size_of::<u8>() * 8 - 2);
+const SENDER_ALIVE: u8 = 0b0100_0000;
 /// Bit mask to mark the sender still has access to the shared data.
-const SENDER_ACCESS: u8 = 1 << (size_of::<u8>() * 8 - 3);
+const SENDER_ACCESS: u8 = 0b0010_0000;
 
 // Status of the message in `Shared`.
-const EMPTY: u8 = 0;
-const FILLED: u8 = 1;
+const EMPTY: u8 = 0b0000_0000;
+const FILLED: u8 = 0b0000_0001;
 
 // Status transitions.
 const MARK_FILLED: u8 = 1; // ADD to go from EMPTY -> FILLED.

--- a/src/oneshot.rs
+++ b/src/oneshot.rs
@@ -241,6 +241,9 @@ impl<T> Receiver<T> {
             return Err(RecvError::Disconnected);
         }
 
+        // Safety: since we're the only thread with access this is safe.
+        let msg = unsafe { (&*shared.message.get()).assume_init_read() };
+
         // Reset the status.
         // Safety: since the `Sender` has been dropped we have unique access to
         // `shared` making Relaxed ordering fine.
@@ -248,9 +251,6 @@ impl<T> Receiver<T> {
             RECEIVER_ALIVE | SENDER_ALIVE | SENDER_ACCESS | EMPTY,
             Ordering::Release,
         );
-
-        // Safety: since we're the only thread with access this is safe.
-        let msg = unsafe { (&*shared.message.get()).assume_init_read() };
         let sender = Sender {
             shared: self.shared,
         };


### PR DESCRIPTION
To match `Receiver::try_reset`.

And some small cleanups.

