### PR TITLE
Fix oneshot channel

### DIFF
--- a/tests/oneshot.rs
+++ b/tests/oneshot.rs
@@ -209,6 +209,13 @@ mod future {
     }
 
     #[test]
+    fn reset_sender_alive() {
+        let (sender, mut receiver) = new_oneshot::<usize>();
+        assert!(receiver.try_reset().is_none());
+        drop(sender);
+    }
+
+    #[test]
     fn sending_wakes_receiver_after_reset() {
         let (sender, mut receiver) = new_oneshot::<usize>();
         drop(sender);


### PR DESCRIPTION
Two commits:

Change oneshot::Receiver::try_recv to not reset the channel

It turns out that resetting the channel as we did in Receiver::try_recv
caused use-after-free and double-free problems. This was often the case
when calling let (msg, _) = receiver.try_recv(), in other words where
the reset receiver was dropped immeditaily.


Check access bit in oneshot::Receiver::try_reset

Before it would if the SENDER_ALIVE bit was not set. This meant that the
Sender could still be alive, as the SENDER_ACCESS bit could still be
set. This causes a problem if the overwriting of the status (in
try_reset) was done before the original Sender unset the SENDER_ACCESS
bit, leading to double-free and use-after-free.

This is a breaking change and would require a v0.2.0

