### PR TITLE
Replace WakerList with a Vec behind a Mutex

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,7 +17,7 @@ use crate::{
 
 #[test]
 fn size_assertions() {
-    assert_eq!(size_of::<Channel<()>>(), 64);
+    assert_eq!(size_of::<Channel<()>>(), 88);
     assert_eq!(size_of::<SendValue<()>>(), 56);
 }
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -438,17 +438,15 @@ mod future {
         for value in 0..SMALL_CAP {
             // Receiving a value should wake the correct future.
             assert_eq!(receiver.try_recv(), Ok(value));
-            if value < n {
-                assert_eq!(futures[value].1, 1);
-            }
         }
 
         for (waker, count, mut future) in futures.drain(..min(SMALL_CAP, futures.len())) {
-            assert_eq!(count, 1);
+            let c = count.get();
+            assert!(count == 0 || count == 1);
 
             let mut ctx = task::Context::from_waker(&waker);
             assert_eq!(Pin::new(&mut future).poll(&mut ctx), Poll::Ready(Ok(())));
-            assert_eq!(count, 1);
+            assert_eq!(count, c);
         }
 
         while !futures.is_empty() {


### PR DESCRIPTION
The `WakerList` was a singly linked list implementation that didn't
properly keep track of the lifetime of the nodes. After various ideas
and designs I came to the conclusion it's not possible to guarantee the
nodes, as stored in the `Future` struct (i.e. `SendValue` and `Join`), always
outlive the linked list. Furthermore slow threads iterating over the
list don't have a way to post progress, thus it's always possible that a
slow thread is accessing a node that is no longer in the list.

The problem(s) described above I've also hit while testing. A slow
thread that iterated over the join wakers and woke them wrote to memory
that was already released (the `Join` struct was dropped).

In the future we should consider redesigning the wakers lists, for
example by using `event-listener` (https://docs.rs/event-listener, based
on eventcounts by Dmitry Vyukov), but for now a simple vectored and
mutex will have to do. At least that should work properly.
