### PR TITLE
Remove futures-test dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ stress_testing = []
 
 [dependencies]
 parking_lot = { version = "0.11.0", default-features = false }
-
-[dev-dependencies]
-futures-test = { version = "0.3.5", default-features = false, features = ["std"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,14 +451,6 @@ impl<T> Drop for Sender<T> {
 }
 
 /// [`Future`] implementation behind [`Sender::send`].
-///
-/// # Safety
-///
-/// It is not safe to leak this `SendValue` (by using [`mem::forget`]). Always
-/// make sure the destructor is run, by calling [`drop`], or letting it go out
-/// of scope.
-///
-/// [`mem::forget`]: std::mem::forget
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct SendValue<'s, T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 
 // TODO: support larger channel, with more slots.
 
-#![feature(cfg_sanitize, maybe_uninit_extra, maybe_uninit_ref)]
+#![feature(cfg_sanitize, maybe_uninit_extra)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -731,7 +731,6 @@ mod future {
     }
 
     #[test]
-    #[ignore = "`forget`ting `SendValue` is memory unsafe"]
     fn forget_send_value() {
         let (sender, mut receiver) = new_small::<usize>();
 
@@ -748,10 +747,9 @@ mod future {
         assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
         std::mem::forget(future);
 
-        // FIXME: because we `forget` the future above the waker count should
-        // remain zero.
-        assert_eq!(receiver.try_recv(), Ok(0));
         assert_eq!(count, 0);
+        assert_eq!(receiver.try_recv(), Ok(0));
+        assert_eq!(count, 1);
     }
 
     #[test]

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -308,11 +308,10 @@ mod future {
     use std::pin::Pin;
     use std::task::{self, Poll};
 
-    use futures_test::task::{new_count_waker, AwokenCount};
-
     use heph_inbox::{new_small, Sender};
 
-    use super::SMALL_CAP;
+    use crate::util::{new_count_waker, AwokenCount};
+    use crate::SMALL_CAP;
 
     macro_rules! pin_stack {
         ($fut: ident) => {
@@ -442,7 +441,7 @@ mod future {
 
         for (waker, count, mut future) in futures.drain(..min(SMALL_CAP, futures.len())) {
             let c = count.get();
-            assert!(count == 0 || count == 1);
+            assert!(c == 0 || c == 1);
 
             let mut ctx = task::Context::from_waker(&waker);
             assert_eq!(Pin::new(&mut future).poll(&mut ctx), Poll::Ready(Ok(())));

--- a/tests/oneshot.rs
+++ b/tests/oneshot.rs
@@ -8,9 +8,7 @@ mod util;
 mod functional {
     use heph_inbox::oneshot::{new_oneshot, Receiver, RecvError, Sender};
 
-    use futures_test::task::new_count_waker;
-
-    use crate::util::{assert_send, assert_sync};
+    use crate::util::{assert_send, assert_sync, new_count_waker};
 
     #[test]
     fn sender_is_send() {
@@ -114,9 +112,9 @@ mod future {
     use std::pin::Pin;
     use std::task::{self, Poll};
 
-    use futures_test::task::new_count_waker;
-
     use heph_inbox::oneshot::new_oneshot;
+
+    use crate::util::new_count_waker;
 
     macro_rules! pin_stack {
         ($fut: ident) => {


### PR DESCRIPTION
Reduce the number of crates to build while testing from 54 to 18.

