### PR TITLE
Allow for arbitrary size channels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1025,6 +1025,7 @@ impl<T> fmt::Debug for Channel<T> {
         let status = self.status.load(Ordering::Relaxed);
         let ref_count = self.ref_count.load(Ordering::Relaxed);
         let sender_count = sender_count(ref_count);
+        let recv_pos = receiver_pos(status, self.slots.len());
         let mut slots = [""; MAX_CAP];
         for n in 0..self.slots.len() {
             slots[n] = dbg_status(slot_status(status, n));
@@ -1034,6 +1035,7 @@ impl<T> fmt::Debug for Channel<T> {
             .field("senders_alive", &sender_count)
             .field("receiver_alive", &has_receiver(ref_count))
             .field("manager_alive", &has_manager(ref_count))
+            .field("receiver_position", &recv_pos)
             .field("slots", &slots)
             .finish()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,15 @@
 // Disallow warnings in examples, we want to set a good example after all.
 #![doc(test(attr(deny(warnings))))]
 
+use std::alloc::{alloc, handle_alloc_error, Layout};
 use std::cell::UnsafeCell;
 use std::error::Error;
 use std::fmt;
 use std::future::Future;
 use std::mem::{drop as unlock, replace, size_of, MaybeUninit};
+use std::ops::Deref;
 use std::pin::Pin;
-use std::ptr::NonNull;
+use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::task::{self, Poll};
 
@@ -99,9 +101,14 @@ pub mod oneshot;
 mod waker;
 use waker::WakerRegistration;
 
+/// The capacity of a small channel.
+const SMALL_CAP: usize = 8;
+/// Maximum capacity of a channel, see [`Channel::new`].
+const MAX_CAP: usize = 29;
+
 /// Create a small bounded channel.
 pub fn new_small<T>() -> (Sender<T>, Receiver<T>) {
-    let channel = NonNull::from(Box::leak(Box::new(Channel::new())));
+    let channel = Channel::new(SMALL_CAP);
     let sender = Sender { channel };
     let receiver = Receiver { channel };
     (sender, receiver)
@@ -144,9 +151,6 @@ const fn has_receiver_or_manager(ref_count: usize) -> bool {
 const fn sender_count(ref_count: usize) -> usize {
     ref_count & !(RECEIVER_ALIVE | RECEIVER_ACCESS | SENDER_ACCESS | MANAGER_ALIVE | MANAGER_ACCESS)
 }
-
-/// The capacity of a small channel.
-const SMALL_CAP: usize = 8;
 
 // Bits to mark the status of a slot.
 const STATUS_BITS: u64 = 2; // Number of bits used per slot.
@@ -318,7 +322,7 @@ impl<T> Sender<T> {
 
     /// Returns the id of this sender.
     pub fn id(&self) -> Id {
-        Id(self.channel.as_ptr() as usize)
+        Id(self.channel.as_ptr() as *const () as usize)
     }
 
     fn channel(&self) -> &Channel<T> {
@@ -405,7 +409,7 @@ impl<T> Clone for Sender<T> {
 impl<T> fmt::Debug for Sender<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Sender")
-            .field("channel", self.channel())
+            .field("channel", &self.channel())
             .finish()
     }
 }
@@ -715,7 +719,7 @@ impl<T> Receiver<T> {
 
     /// Returns the id of this receiver.
     pub fn id(&self) -> Id {
-        Id(self.channel.as_ptr() as usize)
+        Id(self.channel.as_ptr() as *const () as usize)
     }
 
     fn channel(&self) -> &Channel<T> {
@@ -793,7 +797,7 @@ fn try_recv<T>(channel: &Channel<T>) -> Result<T, RecvError> {
 impl<T: fmt::Debug> fmt::Debug for Receiver<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Receiver")
-            .field("channel", self.channel())
+            .field("channel", &self.channel())
             .finish()
     }
 }
@@ -891,6 +895,16 @@ impl<'r, T> Unpin for RecvValue<'r, T> {}
 /// Channel internals shared between zero or more [`Sender`]s, zero or one
 /// [`Receiver`] and zero or one [`Manager`].
 struct Channel<T> {
+    inner: Inner,
+    /// The slots in the channel, see `status` for what slots are used/unused.
+    slots: [UnsafeCell<MaybeUninit<T>>],
+}
+
+/// Inner data of [`Channel`].
+///
+/// This is only in a different struct to calculate the `Layout` of `Channel`,
+/// see [`Channel::new`].
+struct Inner {
     /// Status of the slots.
     ///
     /// This contains the status of the slots. Each status consists of
@@ -900,8 +914,6 @@ struct Channel<T> {
     /// `slots` field. The remaining bits are used by the `Sender` to indicate
     /// its current reading position (modulo `SMALL_CAP`).
     status: AtomicU64,
-    /// The slots in the channel, see `status` for what slots are used/unused.
-    slots: [UnsafeCell<MaybeUninit<T>>; SMALL_CAP],
     /// The number of senders alive. If the [`RECEIVER_ALIVE`] bit is set the
     /// [`Receiver`] is alive. If the [`MANAGER_ALIVE`] bit is the [`Manager`]
     /// is alive.
@@ -917,25 +929,44 @@ unsafe impl<T: Send> Send for Channel<T> {}
 unsafe impl<T> Sync for Channel<T> {}
 
 impl<T> Channel<T> {
+    /// Allocates a new `Channel` on the heap.
+    ///
+    /// `length` must small enough to ensure each slot has 2 bits for the
+    /// status, while ensuring that the remaining bits can store `length` (in
+    /// binary) to keep track of the reading position. This means following must
+    /// hold true where $N is length: `2 ^ (64 - ($N * 2)) >= $N`. The maximum
+    /// is 29.
+    ///
     /// Marks a single [`Receiver`] and [`Sender`] as alive.
-    const fn new() -> Channel<T> {
-        Channel {
-            slots: [
-                UnsafeCell::new(MaybeUninit::uninit()),
-                UnsafeCell::new(MaybeUninit::uninit()),
-                UnsafeCell::new(MaybeUninit::uninit()),
-                UnsafeCell::new(MaybeUninit::uninit()),
-                UnsafeCell::new(MaybeUninit::uninit()),
-                UnsafeCell::new(MaybeUninit::uninit()),
-                UnsafeCell::new(MaybeUninit::uninit()),
-                UnsafeCell::new(MaybeUninit::uninit()),
-            ],
-            status: AtomicU64::new(0),
-            ref_count: AtomicUsize::new(RECEIVER_ALIVE | RECEIVER_ACCESS | SENDER_ACCESS | 1),
-            sender_wakers: const_mutex(Vec::new()),
-            join_wakers: const_mutex(Vec::new()),
-            receiver_waker: WakerRegistration::new(),
+    fn new(length: usize) -> NonNull<Channel<T>> {
+        assert!(length <= MAX_CAP, "length too large");
+
+        // Allocate some raw bytes.
+        // Safety: returns an error on arithmetic overflow, but it should be OK
+        // with a length <= MAX_CAP.
+        let (layout, _) = Layout::array::<UnsafeCell<MaybeUninit<T>>>(length)
+            .and_then(|slots_layout| Layout::new::<Inner>().extend(slots_layout))
+            .unwrap();
+        // Safety: we check if the allocation is successful.
+        let ptr = unsafe { alloc(layout) };
+        if ptr.is_null() {
+            handle_alloc_error(layout);
         }
+        let ptr = ptr::slice_from_raw_parts_mut(ptr as *mut T, length) as *mut Channel<T>;
+
+        // Initialise all fields (that need it).
+        unsafe {
+            ptr::addr_of_mut!((*ptr).inner.status).write(AtomicU64::new(0));
+            ptr::addr_of_mut!((*ptr).inner.ref_count).write(AtomicUsize::new(
+                RECEIVER_ALIVE | RECEIVER_ACCESS | SENDER_ACCESS | 1,
+            ));
+            ptr::addr_of_mut!((*ptr).inner.sender_wakers).write(const_mutex(Vec::new()));
+            ptr::addr_of_mut!((*ptr).inner.join_wakers).write(const_mutex(Vec::new()));
+            ptr::addr_of_mut!((*ptr).inner.receiver_waker).write(WakerRegistration::new());
+        }
+
+        // Safety: checked if the pointer is null above.
+        unsafe { NonNull::new_unchecked(ptr) }
     }
 
     /// Returns the next `task::Waker` to wake, if any.
@@ -964,28 +995,31 @@ impl<T> Channel<T> {
     }
 }
 
+// NOTE: this is here so we don't have to type `self.channel().inner`
+// everywhere.
+impl<T> Deref for Channel<T> {
+    type Target = Inner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
 impl<T> fmt::Debug for Channel<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let status = self.status.load(Ordering::Relaxed);
         let ref_count = self.ref_count.load(Ordering::Relaxed);
         let sender_count = sender_count(ref_count);
+        let mut slots = [""; MAX_CAP];
+        for n in 0..self.slots.len() {
+            slots[n] = dbg_status(slot_status(status, n));
+        }
+        let slots = &slots[..self.slots.len()];
         f.debug_struct("Channel")
             .field("senders_alive", &sender_count)
             .field("receiver_alive", &has_receiver(ref_count))
             .field("manager_alive", &has_manager(ref_count))
-            .field(
-                "slots",
-                &[
-                    dbg_status(slot_status(status, 0)),
-                    dbg_status(slot_status(status, 1)),
-                    dbg_status(slot_status(status, 2)),
-                    dbg_status(slot_status(status, 3)),
-                    dbg_status(slot_status(status, 4)),
-                    dbg_status(slot_status(status, 5)),
-                    dbg_status(slot_status(status, 6)),
-                    dbg_status(slot_status(status, 7)),
-                ],
-            )
+            .field("slots", &slots)
             .finish()
     }
 }
@@ -1096,7 +1130,7 @@ impl<T> Manager<T> {
 impl<T> fmt::Debug for Manager<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Manager")
-            .field("channel", self.channel())
+            .field("channel", &self.channel())
             .finish()
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,8 +8,8 @@ use std::task::{self, Poll, Wake};
 
 use crate::{
     has_status, new_small, receiver_pos, slot_status, Channel, Join, Receiver, SendValue, Sender,
-    ALL_STATUSES_MASK, EMPTY, FILLED, MARK_EMPTIED, MARK_NEXT_POS, MARK_READING, POS_BITS, READING,
-    SMALL_CAP, TAKEN,
+    ALL_STATUSES_MASK, EMPTY, FILLED, MARK_EMPTIED, MARK_NEXT_POS, MARK_READING, MAX_CAP, POS_BITS,
+    READING, SMALL_CAP, TAKEN,
 };
 
 /// Number of times the waker was awoken.
@@ -65,7 +65,7 @@ fn assertions() {
     // correctly.
 
     // Enough bits for the statuses of the slots.
-    assert_eq!(2_usize.pow(POS_BITS as u32), SMALL_CAP);
+    assert!(2_usize.pow(POS_BITS as u32) >= MAX_CAP);
 
     // Status are different.
     assert_ne!(EMPTY, TAKEN);
@@ -180,28 +180,34 @@ fn test_has_status() {
 
 #[test]
 fn test_receiver_pos() {
+    #[rustfmt::skip]
     let tests = &[
-        (0b000_1110010011100100, 0),
-        (0b001_1110010011100100, 1),
-        (0b010_1110010011100100, 2),
-        (0b011_1110010011100100, 3),
-        (0b100_1110010011100100, 4),
-        (0b101_1110010011100100, 5),
-        (0b110_1110010011100100, 6),
-        (0b111_1110010011100100, 7),
+        (0b0000000000000000000000000000000000000000000000000000000000000000, 0),
+        (0b0000010000000000000000000000000000000000000000000000000000000000, 1),
+        (0b0000100000000000000000000000000000000000000000000000000000000000, 2),
+        (0b0000110000000000000000000000000000000000000000000000000000000000, 3),
+        (0b0001000000000000000000000000000000000000000000000000000000000000, 4),
+        (0b0001010000000000000000000000000000000000000000000000000000000000, 5),
+        (0b0001100000000000000000000000000000000000000000000000000000000000, 6),
+        (0b0001110000000000000000000000000000000000000000000000000000000000, 7),
         // Additional bits are ignored.
-        (0b1_000_1110010011100100, 0),
-        (0b1_001_1110010011100100, 1),
-        (0b1_010_1110010011100100, 2),
-        (0b1_011_1110010011100100, 3),
-        (0b1_100_1110010011100100, 4),
-        (0b1_101_1110010011100100, 5),
-        (0b1_110_1110010011100100, 6),
-        (0b1_111_1110010011100100, 7),
+        (0b0000000000000000000000000000000000000000000000000000000000000000, 0),
+        (0b1000010000000000000000000000000000000000000000000000000000000000, 1),
+        (0b1000100000000000000000000000000000000000000000000000000000000000, 2),
+        (0b0100110000000000000000000000000000000000000000000000000000000000, 3),
+        (0b0011000000000000000000000000000000000000000000000000000000000000, 4),
+        (0b0101010000000000000000000000000000000000000000000000000000000000, 5),
+        (0b1001100000000000000000000000000000000000000000000000000000000000, 6),
+        (0b1001110000000000000000000000000000000000000000000000000000000000, 7),
     ];
 
     for (input, want) in tests.into_iter().copied() {
-        assert_eq!(receiver_pos(input), want, "input: {:064b}", input);
+        assert_eq!(
+            receiver_pos(input, SMALL_CAP),
+            want,
+            "input: {:064b}",
+            input
+        );
     }
 }
 
@@ -283,7 +289,7 @@ fn channel_next_sender_waker_three_wakers() {
 fn send_value_removes_waker_from_list_on_drop() {
     let (sender, mut receiver) = new_small::<usize>();
 
-    for _ in 0..SMALL_CAP {
+    for _ in 0..sender.capacity() {
         sender.try_send(123).unwrap();
     }
 
@@ -297,7 +303,7 @@ fn send_value_removes_waker_from_list_on_drop() {
     drop(future);
     assert!(receiver.channel().sender_wakers.lock().is_empty());
 
-    for _ in 0..SMALL_CAP {
+    for _ in 0..receiver.capacity() {
         assert_eq!(receiver.try_recv().unwrap(), 123);
     }
     drop(receiver);
@@ -309,7 +315,7 @@ fn send_value_removes_waker_from_list_on_drop() {
 fn send_value_removes_waker_from_list_on_drop_polled_with_different_wakers() {
     let (sender, mut receiver) = new_small::<usize>();
 
-    for _ in 0..SMALL_CAP {
+    for _ in 0..sender.capacity() {
         sender.try_send(123).unwrap();
     }
 
@@ -326,7 +332,7 @@ fn send_value_removes_waker_from_list_on_drop_polled_with_different_wakers() {
     drop(future);
     assert!(receiver.channel().sender_wakers.lock().is_empty());
 
-    for _ in 0..SMALL_CAP {
+    for _ in 0..receiver.capacity() {
         assert_eq!(receiver.try_recv().unwrap(), 123);
     }
     drop(receiver);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -83,12 +83,12 @@ fn assertions() {
     assert_eq!(READING & !MARK_EMPTIED, EMPTY);
 
     // Changing `Receiver` position doesn't change status of slots.
-    const ORIGINAL_STATUS: usize = 0b1110010011100100;
+    const ORIGINAL_STATUS: u64 = 0b1110010011100100;
     assert_eq!(
         (size_of::<usize>() * 8) - (ORIGINAL_STATUS.leading_zeros() as usize),
         2 * SMALL_CAP
     );
-    let mut status: usize = ORIGINAL_STATUS.wrapping_sub(MARK_NEXT_POS);
+    let mut status: u64 = ORIGINAL_STATUS.wrapping_sub(MARK_NEXT_POS);
     status = status.wrapping_add(MARK_NEXT_POS);
     assert_eq!(status, ORIGINAL_STATUS);
     status = status.wrapping_add(MARK_NEXT_POS);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,8 +8,8 @@ use std::task::{self, Poll, Wake};
 
 use crate::{
     has_status, new_small, receiver_pos, slot_status, Channel, Join, Receiver, SendValue, Sender,
-    ALL_STATUSES_MASK, EMPTY, FILLED, MARK_EMPTIED, MARK_NEXT_POS, MARK_READING, MAX_CAP, POS_BITS,
-    READING, SMALL_CAP, TAKEN,
+    ALL_STATUSES_MASK, EMPTY, FILLED, MARK_EMPTIED, MARK_NEXT_POS, MARK_READING, READING,
+    SMALL_CAP, TAKEN,
 };
 
 /// Number of times the waker was awoken.
@@ -51,7 +51,7 @@ fn new_count_waker() -> (task::Waker, AwokenCount) {
 
 #[test]
 fn size_assertions() {
-    let channel = unsafe { Box::from_raw(Channel::<()>::new(0).as_ptr()) };
+    let channel = unsafe { Box::from_raw(Channel::<()>::new(1).as_ptr()) };
     assert_eq!(size_of_val(&**channel), 112);
     assert_eq!(size_of::<Sender<()>>(), 16);
     assert_eq!(size_of::<Receiver<()>>(), 16);
@@ -63,9 +63,6 @@ fn size_assertions() {
 fn assertions() {
     // Various assertions that must be true for the channel to work
     // correctly.
-
-    // Enough bits for the statuses of the slots.
-    assert!(2_usize.pow(POS_BITS as u32) >= MAX_CAP);
 
     // Status are different.
     assert_ne!(EMPTY, TAKEN);

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -2,443 +2,498 @@
 
 #![feature(once_cell)]
 
-use heph_inbox::{new_small, Manager};
+use heph_inbox::{self as inbox, new, Manager};
 
 #[macro_use]
 mod util;
 
-use util::{DropTest, IsDropped, NeverDrop, SMALL_CAP};
+use util::{DropTest, IsDropped, NeverDrop};
 
 #[test]
 fn empty() {
-    let (sender, receiver) = new_small::<NeverDrop>();
-    drop(sender);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<NeverDrop>(capacity);
+        drop(sender);
+        drop(receiver);
 
-    let (sender, receiver) = new_small::<NeverDrop>();
-    drop(sender);
-    drop(receiver);
+        let (sender, receiver) = new::<NeverDrop>(capacity);
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn empty_cloned() {
-    let (sender, receiver) = new_small::<NeverDrop>();
-    let sender2 = sender.clone();
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<NeverDrop>(capacity);
+        let sender2 = sender.clone();
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
 
-    let (sender, receiver) = new_small::<NeverDrop>();
-    let sender2 = sender.clone();
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
+        let (sender, receiver) = new::<NeverDrop>(capacity);
+        let sender2 = sender.clone();
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn empty_with_manager() {
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    drop(sender);
-    drop(receiver);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        drop(sender);
+        drop(receiver);
+        drop(manager);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    drop(sender);
-    drop(receiver);
-    drop(manager);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        drop(sender);
+        drop(receiver);
+        drop(manager);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    drop(manager);
-    drop(sender);
-    drop(receiver);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        drop(manager);
+        drop(sender);
+        drop(receiver);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    drop(manager);
-    drop(sender);
-    drop(receiver);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        drop(manager);
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn empty_cloned_with_manager() {
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    let sender2 = sender.clone();
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        let sender2 = sender.clone();
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
+        drop(manager);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    let sender2 = sender.clone();
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
-    drop(manager);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        let sender2 = sender.clone();
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
+        drop(manager);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    let sender2 = sender.clone();
-    drop(manager);
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        let sender2 = sender.clone();
+        drop(manager);
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
 
-    let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-    let sender2 = sender.clone();
-    drop(manager);
-    drop(sender);
-    drop(sender2);
-    drop(receiver);
+        let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+        let sender2 = sender.clone();
+        drop(manager);
+        drop(sender);
+        drop(sender2);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn send_single_value_sr() {
-    let (sender, receiver) = new_small();
-    let (value, _check) = DropTest::new();
-    sender.try_send(value).unwrap();
-    drop(sender);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let (value, _check) = DropTest::new();
+        sender.try_send(value).unwrap();
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn send_single_value_rs() {
-    let (sender, receiver) = new_small();
-    let (value, _check) = DropTest::new();
-    sender.try_send(value).unwrap();
-    drop(receiver);
-    drop(sender);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let (value, _check) = DropTest::new();
+        sender.try_send(value).unwrap();
+        drop(receiver);
+        drop(sender);
+    });
 }
 
 #[test]
 fn send_single_value_with_manager() {
-    let (manager, sender, receiver) = Manager::new_small_channel();
-    let (value, _check) = DropTest::new();
-    sender.try_send(value).unwrap();
-    drop(sender);
-    drop(receiver);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, receiver) = Manager::new_channel(capacity);
+        let (value, _check) = DropTest::new();
+        sender.try_send(value).unwrap();
+        drop(sender);
+        drop(receiver);
+        drop(manager);
+    });
 }
 
 #[test]
 fn full_channel_sr() {
-    let (sender, receiver) = new_small();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    drop(sender);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn full_channel_rs() {
-    let (sender, receiver) = new_small();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    drop(receiver);
-    drop(sender);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        drop(receiver);
+        drop(sender);
+    });
 }
 
 #[test]
 fn full_channel_with_manager() {
-    let (manager, sender, receiver) = Manager::new_small_channel();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    drop(sender);
-    drop(receiver);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, receiver) = Manager::new_channel(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        drop(sender);
+        drop(receiver);
+        drop(manager);
+    });
 }
 
 #[test]
 fn value_received_sr() {
-    let (sender, mut receiver) = new_small();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    let _value1 = receiver.try_recv().unwrap();
-    let _value2 = receiver.try_recv().unwrap();
-    drop(sender);
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        let _value1 = receiver.try_recv().unwrap();
+        if capacity > 1 {
+            let _value2 = receiver.try_recv().unwrap();
+        }
+        drop(sender);
+        drop(receiver);
+    });
 }
 
 #[test]
 fn value_received_rs() {
-    let (sender, mut receiver) = new_small();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    let _value1 = receiver.try_recv().unwrap();
-    let _value2 = receiver.try_recv().unwrap();
-    drop(receiver);
-    drop(sender);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        let _value1 = receiver.try_recv().unwrap();
+        if capacity > 1 {
+            let _value2 = receiver.try_recv().unwrap();
+        }
+        drop(receiver);
+        drop(sender);
+    });
 }
 
 #[test]
 fn value_received_with_manager() {
-    let (manager, sender, mut receiver) = Manager::new_small_channel();
-    let _checks: Vec<IsDropped> = (0..SMALL_CAP)
-        .into_iter()
-        .map(|_| {
-            let (value, check) = DropTest::new();
-            sender.try_send(value).unwrap();
-            check
-        })
-        .collect();
-    let _value1 = receiver.try_recv().unwrap();
-    let _value2 = receiver.try_recv().unwrap();
-    drop(receiver);
-    drop(sender);
-    drop(manager);
+    with_all_capacities!(|capacity| {
+        let (manager, sender, mut receiver) = Manager::new_channel(capacity);
+        let _checks: Vec<IsDropped> = (0..capacity)
+            .into_iter()
+            .map(|_| {
+                let (value, check) = DropTest::new();
+                sender.try_send(value).unwrap();
+                check
+            })
+            .collect();
+        let _value1 = receiver.try_recv().unwrap();
+        if capacity > 1 {
+            let _value2 = receiver.try_recv().unwrap();
+        }
+        drop(receiver);
+        drop(sender);
+        drop(manager);
+    });
 }
 
 mod threaded {
+    use std::cmp::min;
     use std::thread;
     use std::time::Duration;
 
-    use heph_inbox::{new_small, Manager};
+    use heph_inbox::{self as inbox, new, Manager};
 
-    use super::{DropTest, NeverDrop, SMALL_CAP};
+    use crate::util::{DropTest, NeverDrop};
 
     #[test]
     fn empty() {
-        let (sender, receiver) = new_small::<NeverDrop>();
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new::<NeverDrop>(capacity);
 
-        start_threads!(
-            {
-                drop(sender);
-            },
-            {
-                drop(receiver);
-            }
-        );
+            start_threads!(
+                {
+                    drop(sender);
+                },
+                {
+                    drop(receiver);
+                }
+            );
+        })
     }
 
     #[test]
     fn empty_cloned() {
-        let (sender, receiver) = new_small::<NeverDrop>();
-        let sender2 = sender.clone();
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new::<NeverDrop>(capacity);
+            let sender2 = sender.clone();
 
-        start_threads!(
-            {
-                drop(sender);
-            },
-            {
-                drop(sender2);
-            },
-            {
-                drop(receiver);
-            }
-        );
+            start_threads!(
+                {
+                    drop(sender);
+                },
+                {
+                    drop(sender2);
+                },
+                {
+                    drop(receiver);
+                }
+            );
+        });
     }
 
     #[test]
     fn empty_with_manager() {
-        let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
+        with_all_capacities!(|capacity| {
+            let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
 
-        start_threads!(
-            {
-                drop(sender);
-            },
-            {
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            },
-        );
+            start_threads!(
+                {
+                    drop(sender);
+                },
+                {
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
+                },
+            );
+        });
     }
 
     #[test]
     fn empty_cloned_with_manager() {
-        let (manager, sender, receiver) = Manager::<NeverDrop>::new_small_channel();
-        let sender2 = sender.clone();
+        with_all_capacities!(|capacity| {
+            let (manager, sender, receiver) = Manager::<NeverDrop>::new_channel(capacity);
+            let sender2 = sender.clone();
 
-        start_threads!(
-            {
-                drop(sender);
-            },
-            {
-                drop(sender2);
-            },
-            {
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            },
-        );
+            start_threads!(
+                {
+                    drop(sender);
+                },
+                {
+                    drop(sender2);
+                },
+                {
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
+                },
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn send_single_value() {
-        let (sender, receiver) = new_small();
-        let (value, _check) = DropTest::new();
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new(capacity);
+            let (value, _check) = DropTest::new();
 
-        start_threads!(
-            {
-                expect_send!(sender, value);
-                drop(sender);
-            },
-            {
-                // Give the sender a chance to send the message.
-                thread::sleep(Duration::from_millis(10));
-                drop(receiver);
-            }
-        );
+            start_threads!(
+                {
+                    expect_send!(sender, value);
+                    drop(sender);
+                },
+                {
+                    // Give the sender a chance to send the message.
+                    thread::sleep(Duration::from_millis(10));
+                    drop(receiver);
+                }
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn send_single_value_with_manager() {
-        let (manager, sender, receiver) = Manager::new_small_channel();
-        let (value, _check) = DropTest::new();
+        with_all_capacities!(|capacity| {
+            let (manager, sender, receiver) = Manager::new_channel(capacity);
+            let (value, _check) = DropTest::new();
 
-        start_threads!(
-            {
-                expect_send!(sender, value);
-                drop(sender);
-            },
-            {
-                // Give the sender a chance to send the message.
-                thread::sleep(Duration::from_millis(10));
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            },
-        );
+            start_threads!(
+                {
+                    expect_send!(sender, value);
+                    drop(sender);
+                },
+                {
+                    // Give the sender a chance to send the message.
+                    thread::sleep(Duration::from_millis(10));
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
+                },
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn full_channel() {
-        let (sender, receiver) = new_small();
-        let (values, _checks) = DropTest::many(SMALL_CAP);
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new(capacity);
+            let (values, _checks) = DropTest::many(capacity);
 
-        start_threads!(
-            {
-                for value in values {
-                    expect_send!(sender, value);
+            start_threads!(
+                {
+                    for value in values {
+                        expect_send!(sender, value);
+                    }
+                    drop(sender);
+                },
+                {
+                    // Give the sender a chance to send the messages.
+                    thread::sleep(Duration::from_millis(200));
+                    drop(receiver);
                 }
-                drop(sender);
-            },
-            {
-                // Give the sender a chance to send the messages.
-                thread::sleep(Duration::from_millis(200));
-                drop(receiver);
-            }
-        );
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn full_channel_with_manager() {
-        let (manager, sender, receiver) = Manager::new_small_channel();
-        let (values, _checks) = DropTest::many(SMALL_CAP);
+        with_all_capacities!(|capacity| {
+            let (manager, sender, receiver) = Manager::new_channel(capacity);
+            let (values, _checks) = DropTest::many(capacity);
 
-        start_threads!(
-            {
-                for value in values {
-                    expect_send!(sender, value);
-                }
-                drop(sender);
-            },
-            {
-                // Give the sender a chance to send the messages.
-                thread::sleep(Duration::from_millis(200));
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            },
-        );
+            start_threads!(
+                {
+                    for value in values {
+                        expect_send!(sender, value);
+                    }
+                    drop(sender);
+                },
+                {
+                    // Give the sender a chance to send the messages.
+                    thread::sleep(Duration::from_millis(200));
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
+                },
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn value_received() {
-        let (sender, mut receiver) = new_small();
-        let (values, _checks) = DropTest::many(SMALL_CAP);
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new(capacity);
+            let (values, _checks) = DropTest::many(capacity);
 
-        start_threads!(
-            {
-                for value in values {
-                    expect_send!(sender, value);
-                }
-                drop(sender);
-            },
-            {
-                for _ in 0..2 {
-                    r#loop! {
-                        match receiver.try_recv() {
-                            Ok(..) => break,
-                            Err(heph_inbox::RecvError::Empty) => {} // Try again.
-                            Err(err) => panic!("unexpected error receiving: {}", err),
+            start_threads!(
+                {
+                    for value in values {
+                        expect_send!(sender, value);
+                    }
+                    drop(sender);
+                },
+                {
+                    let receive_max = min(2, capacity);
+                    for _ in 0..receive_max {
+                        r#loop! {
+                            match receiver.try_recv() {
+                                Ok(..) => break,
+                                Err(inbox::RecvError::Empty) => {} // Try again.
+                                Err(err) => panic!("unexpected error receiving: {}", err),
+                            }
                         }
                     }
+                    // Give the sender a chance to send the remaining messages.
+                    thread::sleep(Duration::from_millis(200));
+                    drop(receiver);
                 }
-                // Give the sender a chance to send the remaining messages.
-                thread::sleep(Duration::from_millis(200));
-                drop(receiver);
-            }
-        );
+            );
+        });
     }
 
     #[test]
     #[cfg_attr(miri, ignore)] // `sleep` not supported.
     fn value_received_with_manager() {
-        let (manager, sender, mut receiver) = Manager::new_small_channel();
-        let (values, _checks) = DropTest::many(SMALL_CAP);
+        with_all_capacities!(|capacity| {
+            let (manager, sender, mut receiver) = Manager::new_channel(capacity);
+            let (values, _checks) = DropTest::many(capacity);
 
-        start_threads!(
-            {
-                for value in values {
-                    expect_send!(sender, value);
-                }
-                drop(sender);
-            },
-            {
-                for _ in 0..2 {
-                    r#loop! {
-                        match receiver.try_recv() {
-                            Ok(..) => break,
-                            Err(heph_inbox::RecvError::Empty) => {} // Try again.
-                            Err(err) => panic!("unexpected error receiving: {}", err),
+            start_threads!(
+                {
+                    for value in values {
+                        expect_send!(sender, value);
+                    }
+                    drop(sender);
+                },
+                {
+                    let receive_max = min(2, capacity);
+                    for _ in 0..receive_max {
+                        r#loop! {
+                            match receiver.try_recv() {
+                                Ok(..) => break,
+                                Err(inbox::RecvError::Empty) => {} // Try again.
+                                Err(err) => panic!("unexpected error receiving: {}", err),
+                            }
                         }
                     }
+                    // Give the sender a chance to send the remaining messages.
+                    thread::sleep(Duration::from_millis(200));
+                    drop(receiver);
+                },
+                {
+                    drop(manager);
                 }
-                // Give the sender a chance to send the remaining messages.
-                thread::sleep(Duration::from_millis(200));
-                drop(receiver);
-            },
-            {
-                drop(manager);
-            }
-        );
+            );
+        });
     }
 }

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -2,7 +2,9 @@
 
 #![feature(once_cell)]
 
-use heph_inbox::{new_small, Manager, Receiver, RecvError, SendError, SendValue, Sender};
+use heph_inbox::{
+    self as inbox, new_small, Manager, Receiver, RecvError, SendError, SendValue, Sender, MAX_CAP,
+};
 
 mod util;
 
@@ -49,10 +51,24 @@ fn send_value_is_sync() {
 }
 
 #[test]
+#[should_panic = "inbox channel capacity must be between 1 and 29"]
+fn capacity_of_zero_should_panic() {
+    let _ = inbox::new::<()>(0);
+}
+
+#[test]
+#[should_panic = "inbox channel capacity must be between 1 and 29"]
+fn capacity_too_large_should_panic() {
+    let _ = inbox::new::<()>(MAX_CAP + 1);
+}
+
+#[test]
 fn capacities_are_correct() {
-    let (sender, receiver) = new_small::<()>();
-    assert_eq!(sender.capacity(), SMALL_CAP);
-    assert_eq!(receiver.capacity(), SMALL_CAP);
+    for capacity in 1..=MAX_CAP {
+        let (sender, receiver) = inbox::new::<()>(capacity);
+        assert_eq!(sender.capacity(), capacity);
+        assert_eq!(receiver.capacity(), capacity);
+    }
 }
 
 #[test]

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -1,14 +1,15 @@
 //! Functional tests.
 
-#![feature(once_cell)]
+#![feature(drain_filter, once_cell)]
 
 use heph_inbox::{
-    self as inbox, new_small, Manager, Receiver, RecvError, SendError, SendValue, Sender, MAX_CAP,
+    self as inbox, new, Manager, Receiver, RecvError, SendError, SendValue, Sender, MAX_CAP,
 };
 
+#[macro_use]
 mod util;
 
-use util::{assert_send, assert_sync, SMALL_CAP};
+use util::{assert_send, assert_sync};
 
 #[test]
 fn sender_is_send() {
@@ -73,136 +74,160 @@ fn capacities_are_correct() {
 
 #[test]
 fn identifiers() {
-    let (sender1a, receiver1a) = new_small::<()>();
-    let sender1b = sender1a.clone();
-    let (sender2a, receiver2a) = new_small::<()>();
-    let sender2b = sender2a.clone();
+    with_all_capacities!(|capacity| {
+        let (sender1a, receiver1a) = new::<()>(capacity);
+        let sender1b = sender1a.clone();
+        let (sender2a, receiver2a) = new::<()>(capacity);
+        let sender2b = sender2a.clone();
 
-    assert_eq!(sender1a.id(), sender1a.id());
-    assert_eq!(sender1a.id(), sender1b.id());
-    assert_eq!(sender1a.id(), receiver1a.id());
-    assert_eq!(receiver1a.id(), sender1a.id());
-    assert_eq!(receiver1a.id(), sender1b.id());
-    assert_eq!(receiver1a.id(), receiver1a.id());
+        assert_eq!(sender1a.id(), sender1a.id());
+        assert_eq!(sender1a.id(), sender1b.id());
+        assert_eq!(sender1a.id(), receiver1a.id());
+        assert_eq!(receiver1a.id(), sender1a.id());
+        assert_eq!(receiver1a.id(), sender1b.id());
+        assert_eq!(receiver1a.id(), receiver1a.id());
 
-    assert_ne!(sender1a.id(), sender2a.id());
-    assert_ne!(sender1a.id(), sender2b.id());
-    assert_ne!(sender1a.id(), receiver2a.id());
-    assert_ne!(receiver1a.id(), sender2a.id());
-    assert_ne!(receiver1a.id(), sender2b.id());
-    assert_ne!(receiver1a.id(), receiver2a.id());
+        assert_ne!(sender1a.id(), sender2a.id());
+        assert_ne!(sender1a.id(), sender2b.id());
+        assert_ne!(sender1a.id(), receiver2a.id());
+        assert_ne!(receiver1a.id(), sender2a.id());
+        assert_ne!(receiver1a.id(), sender2b.id());
+        assert_ne!(receiver1a.id(), receiver2a.id());
+    });
 }
 
 #[test]
 fn sending_and_receiving_value() {
-    let (sender, mut receiver) = new_small::<usize>();
-    sender.try_send(123).unwrap();
-    assert_eq!(receiver.try_recv().unwrap(), 123);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        sender.try_send(123).unwrap();
+        assert_eq!(receiver.try_recv().unwrap(), 123);
+    });
 }
 
 #[test]
 fn receiving_from_empty_channel() {
-    let (_sender, mut receiver) = new_small::<usize>();
-    assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Empty);
+    with_all_capacities!(|capacity| {
+        let (_sender, mut receiver) = new::<usize>(capacity);
+        assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Empty);
+    });
 }
 
 #[test]
 fn receiving_from_disconnected_channel() {
-    let (sender, mut receiver) = new_small::<usize>();
-    drop(sender);
-    assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Disconnected);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        drop(sender);
+        assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Disconnected);
+    });
 }
 
 #[test]
 fn sending_into_full_channel() {
-    let (sender, receiver) = new_small::<usize>();
-    for value in 0..SMALL_CAP {
-        sender.try_send(value).unwrap();
-    }
-    assert_eq!(
-        sender.try_send(SMALL_CAP + 1),
-        Err(SendError::Full(SMALL_CAP + 1))
-    );
-    drop(receiver);
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<usize>(capacity);
+        for value in 0..capacity {
+            sender.try_send(value).unwrap();
+        }
+        assert_eq!(
+            sender.try_send(capacity + 1),
+            Err(SendError::Full(capacity + 1))
+        );
+        drop(receiver);
+    });
 }
 
 #[test]
 fn send_len_values_send_then_recv() {
-    let (sender, mut receiver) = new_small::<usize>();
-    for value in 0..SMALL_CAP {
-        sender.try_send(value).unwrap();
-    }
-    assert!(sender.try_send(SMALL_CAP + 1).is_err());
-    for value in 0..SMALL_CAP {
-        assert_eq!(receiver.try_recv().unwrap(), value);
-    }
-    assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Empty);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        for value in 0..capacity {
+            sender.try_send(value).unwrap();
+        }
+        assert!(sender.try_send(capacity + 1).is_err());
+        for value in 0..capacity {
+            assert_eq!(receiver.try_recv().unwrap(), value);
+        }
+        assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Empty);
+    });
 }
 
 #[test]
 fn send_len_values_interleaved() {
-    let (sender, mut receiver) = new_small::<usize>();
-    for value in 0..SMALL_CAP {
-        sender.try_send(value).unwrap();
-        assert_eq!(receiver.try_recv().unwrap(), value);
-    }
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        for value in 0..capacity {
+            sender.try_send(value).unwrap();
+            assert_eq!(receiver.try_recv().unwrap(), value);
+        }
+    });
 }
 
 #[test]
 fn send_2_len_values_send_then_recv() {
-    let (sender, mut receiver) = new_small::<usize>();
-    for value in 0..SMALL_CAP {
-        sender.try_send(value).unwrap();
-    }
-    for value in 0..SMALL_CAP {
-        assert_eq!(receiver.try_recv().unwrap(), value);
-        sender.try_send(SMALL_CAP + value).unwrap();
-    }
-    for value in 0..SMALL_CAP {
-        assert_eq!(receiver.try_recv().unwrap(), SMALL_CAP + value);
-    }
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        for value in 0..capacity {
+            sender.try_send(value).unwrap();
+        }
+        for value in 0..capacity {
+            assert_eq!(receiver.try_recv().unwrap(), value);
+            sender.try_send(capacity + value).unwrap();
+        }
+        for value in 0..capacity {
+            assert_eq!(receiver.try_recv().unwrap(), capacity + value);
+        }
+    });
 }
 
 #[test]
 fn send_2_len_values_interleaved() {
-    let (sender, mut receiver) = new_small::<usize>();
-    for value in 0..2 * SMALL_CAP {
-        sender.try_send(value).unwrap();
-        assert_eq!(receiver.try_recv().unwrap(), value);
-    }
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        for value in 0..2 * capacity {
+            sender.try_send(value).unwrap();
+            assert_eq!(receiver.try_recv().unwrap(), value);
+        }
+    });
 }
 
 #[test]
 fn sender_disconnected_after_send() {
-    let (sender, mut receiver) = new_small::<usize>();
-    sender.try_send(123).unwrap();
-    drop(sender);
-    assert_eq!(receiver.try_recv().unwrap(), 123);
-    assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Disconnected);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        sender.try_send(123).unwrap();
+        drop(sender);
+        assert_eq!(receiver.try_recv().unwrap(), 123);
+        assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Disconnected);
+    });
 }
 
 #[test]
 fn sender_disconnected_after_send_len() {
-    let (sender, mut receiver) = new_small::<usize>();
-    for value in 0..SMALL_CAP {
-        sender.try_send(value).unwrap();
-    }
-    drop(sender);
-    for value in 0..SMALL_CAP {
-        assert_eq!(receiver.try_recv().unwrap(), value);
-    }
-    assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Disconnected);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        for value in 0..capacity {
+            sender.try_send(value).unwrap();
+        }
+        drop(sender);
+        for value in 0..capacity {
+            assert_eq!(receiver.try_recv().unwrap(), value);
+        }
+        assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Disconnected);
+    });
 }
 
 #[test]
 fn sender_disconnected_after_send_2_len() {
-    let (sender, mut receiver) = new_small::<usize>();
-    for value in 0..2 * SMALL_CAP {
-        sender.try_send(value).unwrap();
-        assert_eq!(receiver.try_recv().unwrap(), value);
-    }
-    drop(sender);
-    assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Disconnected);
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        for value in 0..2 * capacity {
+            sender.try_send(value).unwrap();
+            assert_eq!(receiver.try_recv().unwrap(), value);
+        }
+        drop(sender);
+        assert_eq!(receiver.try_recv().unwrap_err(), RecvError::Disconnected);
+    });
 }
 
 const LARGE: usize = 1_000_000;
@@ -210,27 +235,58 @@ const LARGE: usize = 1_000_000;
 #[test]
 #[cfg_attr(not(feature = "stress_testing"), ignore)]
 fn stress_sending_interleaved() {
-    let (sender, mut receiver) = new_small::<usize>();
-    for value in 0..LARGE {
-        sender.try_send(value).unwrap();
-        assert_eq!(receiver.try_recv().unwrap(), value);
-    }
-    assert_eq!(receiver.try_recv(), Err(RecvError::Empty));
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
+        for value in 0..LARGE {
+            sender.try_send(value).unwrap();
+            assert_eq!(receiver.try_recv().unwrap(), value);
+        }
+        assert_eq!(receiver.try_recv(), Err(RecvError::Empty));
+    });
 }
 
 #[test]
 #[cfg_attr(not(feature = "stress_testing"), ignore)]
 fn stress_sending_fill() {
-    for n in 1..=(SMALL_CAP - 1) {
-        let (sender, mut receiver) = new_small::<usize>();
+    // NOTE: this test is only run for a limited number of capacities, because
+    // it doesn't work for all of them. The problem is the wrap around of the
+    // receiver position with capacities that are **not** a power of two.
+    //
+    // For example taking a capacity of 5. The maximum receiver position is 63
+    // (6 bits), which is index 3. The next value will be 0 (with wraps around),
+    // which is index 0. This means we've skipped index 4.
+    //
+    // The crate doesn't guaranteed FIFO ordering so it's fine, but this test
+    // assumes it.
 
-        for value in 0..(LARGE / n) {
-            for n in 0..n {
+    /// Iterator for all powers of two in the range `1..=MAX_CAP`.
+    struct PowersOfTwo(usize);
+
+    impl Iterator for PowersOfTwo {
+        type Item = usize;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.0 > MAX_CAP {
+                None
+            } else {
+                let value = self.0;
+                self.0 <<= 1;
+                Some(value)
+            }
+        }
+    }
+    for capacity in PowersOfTwo(1) {
+        let (sender, mut receiver) = new::<usize>(capacity);
+
+        let mut value = 0;
+        for _ in 0..(LARGE / capacity) {
+            for n in 0..capacity {
                 sender.try_send(value + n).unwrap();
             }
-            for n in 0..n {
+            for n in 0..capacity {
                 assert_eq!(receiver.try_recv().unwrap(), value + n);
             }
+            value += capacity;
         }
 
         assert_eq!(receiver.try_recv(), Err(RecvError::Empty));
@@ -239,81 +295,91 @@ fn stress_sending_fill() {
 
 #[test]
 fn sender_is_connected() {
-    let (sender, receiver) = new_small::<usize>();
-    assert!(sender.is_connected());
-    drop(receiver);
-    assert!(!sender.is_connected());
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<usize>(capacity);
+        assert!(sender.is_connected());
+        drop(receiver);
+        assert!(!sender.is_connected());
+    });
 }
 
 #[test]
 fn receiver_is_connected() {
-    let (sender, receiver) = new_small::<usize>();
-    assert!(receiver.is_connected());
-    drop(sender);
-    assert!(!receiver.is_connected());
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<usize>(capacity);
+        assert!(receiver.is_connected());
+        drop(sender);
+        assert!(!receiver.is_connected());
+    });
 }
 
 #[test]
 fn same_channel() {
-    let (sender1a, _) = new_small::<usize>();
-    let sender1b = sender1a.clone();
-    let (sender2a, _) = new_small::<usize>();
-    let sender2b = sender2a.clone();
+    with_all_capacities!(|capacity| {
+        let (sender1a, _) = new::<usize>(capacity);
+        let sender1b = sender1a.clone();
+        let (sender2a, _) = new::<usize>(capacity);
+        let sender2b = sender2a.clone();
 
-    assert!(sender1a.same_channel(&sender1a));
-    assert!(sender1a.same_channel(&sender1b));
-    assert!(!sender1a.same_channel(&sender2a));
-    assert!(!sender1a.same_channel(&sender2b));
-    assert!(sender1b.same_channel(&sender1a));
-    assert!(sender1b.same_channel(&sender1b));
-    assert!(!sender1b.same_channel(&sender2a));
-    assert!(!sender1b.same_channel(&sender2b));
+        assert!(sender1a.same_channel(&sender1a));
+        assert!(sender1a.same_channel(&sender1b));
+        assert!(!sender1a.same_channel(&sender2a));
+        assert!(!sender1a.same_channel(&sender2b));
+        assert!(sender1b.same_channel(&sender1a));
+        assert!(sender1b.same_channel(&sender1b));
+        assert!(!sender1b.same_channel(&sender2a));
+        assert!(!sender1b.same_channel(&sender2b));
 
-    assert!(!sender2a.same_channel(&sender1a));
-    assert!(!sender2a.same_channel(&sender1b));
-    assert!(sender2a.same_channel(&sender2a));
-    assert!(sender2a.same_channel(&sender2b));
-    assert!(!sender2b.same_channel(&sender1a));
-    assert!(!sender2b.same_channel(&sender1b));
-    assert!(sender2b.same_channel(&sender2a));
-    assert!(sender2b.same_channel(&sender2b));
+        assert!(!sender2a.same_channel(&sender1a));
+        assert!(!sender2a.same_channel(&sender1b));
+        assert!(sender2a.same_channel(&sender2a));
+        assert!(sender2a.same_channel(&sender2b));
+        assert!(!sender2b.same_channel(&sender1a));
+        assert!(!sender2b.same_channel(&sender1b));
+        assert!(sender2b.same_channel(&sender2a));
+        assert!(sender2b.same_channel(&sender2b));
+    });
 }
 
 #[test]
 fn sends_to() {
-    let (sender1a, receiver1) = new_small::<usize>();
-    let sender1b = sender1a.clone();
-    let (sender2a, receiver2) = new_small::<usize>();
-    let sender2b = sender2a.clone();
+    with_all_capacities!(|capacity| {
+        let (sender1a, receiver1) = new::<usize>(capacity);
+        let sender1b = sender1a.clone();
+        let (sender2a, receiver2) = new::<usize>(capacity);
+        let sender2b = sender2a.clone();
 
-    assert!(sender1a.sends_to(&receiver1));
-    assert!(!sender1a.sends_to(&receiver2));
-    assert!(sender1b.sends_to(&receiver1));
-    assert!(!sender1b.sends_to(&receiver2));
+        assert!(sender1a.sends_to(&receiver1));
+        assert!(!sender1a.sends_to(&receiver2));
+        assert!(sender1b.sends_to(&receiver1));
+        assert!(!sender1b.sends_to(&receiver2));
 
-    assert!(!sender2a.sends_to(&receiver1));
-    assert!(sender2a.sends_to(&receiver2));
-    assert!(!sender2b.sends_to(&receiver1));
-    assert!(sender2b.sends_to(&receiver2));
+        assert!(!sender2a.sends_to(&receiver1));
+        assert!(sender2a.sends_to(&receiver2));
+        assert!(!sender2b.sends_to(&receiver1));
+        assert!(sender2b.sends_to(&receiver2));
+    });
 }
 
 #[test]
 fn receiver_new_sender() {
-    let (sender, mut receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
 
-    let sender2 = receiver.new_sender();
-    assert!(sender2.sends_to(&receiver));
-    assert!(sender2.same_channel(&sender));
+        let sender2 = receiver.new_sender();
+        assert!(sender2.sends_to(&receiver));
+        assert!(sender2.same_channel(&sender));
 
-    drop(sender);
-    assert!(sender2.is_connected());
-    assert!(receiver.is_connected());
+        drop(sender);
+        assert!(sender2.is_connected());
+        assert!(receiver.is_connected());
 
-    sender2.try_send(123).unwrap();
-    assert_eq!(receiver.try_recv().unwrap(), 123);
+        sender2.try_send(123).unwrap();
+        assert_eq!(receiver.try_recv().unwrap(), 123);
 
-    drop(receiver);
-    assert!(!sender2.is_connected());
+        drop(receiver);
+        assert!(!sender2.is_connected());
+    });
 }
 
 mod future {
@@ -324,10 +390,9 @@ mod future {
     use std::pin::Pin;
     use std::task::{self, Poll};
 
-    use heph_inbox::{new_small, Sender};
+    use heph_inbox::{self as inbox, new};
 
-    use crate::util::{new_count_waker, AwokenCount};
-    use crate::SMALL_CAP;
+    use crate::util::new_count_waker;
 
     macro_rules! pin_stack {
         ($fut: ident) => {
@@ -339,144 +404,148 @@ mod future {
 
     #[test]
     fn send_value() {
-        let (sender, mut receiver) = new_small::<usize>();
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new::<usize>(capacity);
 
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
 
-        let future = sender.send(10);
-        pin_stack!(future);
+            let future = sender.send(10);
+            pin_stack!(future);
 
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Ok(())));
-        assert_eq!(count, 0);
-        assert_eq!(receiver.try_recv(), Ok(10));
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Ok(())));
+            assert_eq!(count, 0);
+            assert_eq!(receiver.try_recv(), Ok(10));
+        });
     }
 
     #[test]
     fn send_value_full_channel() {
-        let (sender, mut receiver) = new_small::<usize>();
-        // Fill the channel.
-        for value in 0..SMALL_CAP {
-            sender.try_send(value).unwrap();
-        }
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new::<usize>(capacity);
+            // Fill the channel.
+            for value in 0..capacity {
+                sender.try_send(value).unwrap();
+            }
 
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
 
-        let future = sender.send(SMALL_CAP);
-        pin_stack!(future);
+            let future = sender.send(capacity);
+            pin_stack!(future);
 
-        // Channel should be full.
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-        assert_eq!(count, 0);
+            // Channel should be full.
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            assert_eq!(count, 0);
 
-        // Receiving a value should wake a sender.
-        assert_eq!(receiver.try_recv(), Ok(0));
-        assert_eq!(count, 1);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Ok(())));
+            // Receiving a value should wake a sender.
+            assert_eq!(receiver.try_recv(), Ok(0));
+            assert_eq!(count, 1);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Ok(())));
 
-        for want in 1..SMALL_CAP + 1 {
-            assert_eq!(receiver.try_recv(), Ok(want));
-        }
+            for want in 1..capacity + 1 {
+                assert_eq!(receiver.try_recv(), Ok(want));
+            }
+        });
     }
 
     #[test]
     fn send_many_values() {
-        let (sender, mut receiver) = new_small::<usize>();
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new::<usize>(capacity);
 
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
 
-        for value in 0..SMALL_CAP {
-            let future = sender.send(value);
-            pin_stack!(future);
+            for value in 0..capacity {
+                let future = sender.send(value);
+                pin_stack!(future);
 
-            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Ok(())));
-            assert_eq!(count, 0);
-        }
+                assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Ok(())));
+                assert_eq!(count, 0);
+            }
 
-        for value in 0..SMALL_CAP {
-            assert_eq!(receiver.try_recv(), Ok(value));
-        }
+            for value in 0..capacity {
+                assert_eq!(receiver.try_recv(), Ok(value));
+            }
+        });
     }
 
     #[test]
     fn send_many_values_interleaved() {
-        let (sender, mut receiver) = new_small::<usize>();
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new::<usize>(capacity);
 
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
 
-        for value in 0..SMALL_CAP {
-            let future = sender.send(value);
-            pin_stack!(future);
+            for value in 0..capacity {
+                let future = sender.send(value);
+                pin_stack!(future);
 
-            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Ok(())));
-            assert_eq!(count, 0);
+                assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Ok(())));
+                assert_eq!(count, 0);
 
-            assert_eq!(receiver.try_recv(), Ok(value));
-        }
+                assert_eq!(receiver.try_recv(), Ok(value));
+            }
+        });
     }
 
     // Test where `n` sender try to send into a full channel.
     fn send_many_values_full_channel_test(n: usize) {
-        let (sender, mut receiver) = new_small::<usize>();
-        // Fill the channel.
-        for value in 0..SMALL_CAP {
-            sender.try_send(value).unwrap();
-        }
-
-        // Create a `Sender` for each `SendValue` future.
-        let mut senders = (0..n)
-            .map(|_| sender.clone())
-            .collect::<Vec<Sender<usize>>>();
-        let mut senders = &mut *senders;
-
-        // Create a number of `SendValue` futures.
-        let mut futures: Vec<(task::Waker, AwokenCount, _)> = Vec::with_capacity(n);
-        for index in 0..n {
-            let (waker, count) = new_count_waker();
-            let mut ctx = task::Context::from_waker(&waker);
-
-            // Work around borrow rules: ensure that we only access a single
-            // sender in the vector at a time.
-            let (head, tail) = senders.split_first_mut().unwrap();
-            senders = tail;
-            let mut future = Box::pin(head.send(index + SMALL_CAP));
-
-            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-            assert_eq!(count, 0);
-
-            futures.push((waker, count, future));
-        }
-
-        for value in 0..SMALL_CAP {
-            // Receiving a value should wake the correct future.
-            assert_eq!(receiver.try_recv(), Ok(value));
-        }
-
-        for (waker, count, mut future) in futures.drain(..min(SMALL_CAP, futures.len())) {
-            let c = count.get();
-            assert!(c == 0 || c == 1);
-
-            let mut ctx = task::Context::from_waker(&waker);
-            assert_eq!(Pin::new(&mut future).poll(&mut ctx), Poll::Ready(Ok(())));
-            assert_eq!(count, c);
-        }
-
-        while !futures.is_empty() {
-            for value in (0..futures.len()).take(SMALL_CAP) {
-                assert_eq!(receiver.try_recv(), Ok(value + SMALL_CAP));
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new::<usize>(capacity);
+            // Fill the channel.
+            for value in 0..capacity {
+                sender.try_send(value).unwrap();
             }
 
-            for (waker, count, mut future) in futures.drain(..min(SMALL_CAP, futures.len())) {
-                assert_eq!(count, 1);
+            // Create a `Sender` for each `SendValue` future.
+            let mut senders = (0..n).map(|_| sender.clone()).collect::<Vec<_>>();
+            let mut senders = &mut *senders;
 
+            // Create a number of `SendValue` futures.
+            let mut futures = Vec::with_capacity(n);
+            for index in 0..n {
+                let (waker, count) = new_count_waker();
                 let mut ctx = task::Context::from_waker(&waker);
-                assert_eq!(Pin::new(&mut future).poll(&mut ctx), Poll::Ready(Ok(())));
-                assert_eq!(count, 1);
+
+                // Work around borrow rules: ensure that we only access a single
+                // sender in the vector at a time.
+                let (head, tail) = senders.split_first_mut().unwrap();
+                senders = tail;
+                let mut future = Box::pin(head.send(index));
+
+                assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+                assert_eq!(count, 0);
+
+                futures.push((waker, count, future));
             }
-        }
+
+            // The sender should be awoken, however because we don't guarantee
+            // FIFO we don't the exact order in which the senders are awoken.
+            // `Channel::wake_next_sender` use of `Vec::swap_remove` makes it a
+            // bit hard to predict so we just check that at least one sender is
+            // awoken for each received message.
+            while !futures.is_empty() {
+                let n = min(capacity, futures.len());
+                for _ in 0..n {
+                    receiver.try_recv().unwrap();
+                }
+
+                let mut send = 0;
+                for (waker, count, mut future) in futures.drain_filter(|(_, c, _)| c.get() == 1) {
+                    let mut ctx = task::Context::from_waker(&waker);
+                    assert_eq!(Pin::new(&mut future).poll(&mut ctx), Poll::Ready(Ok(())));
+                    assert_eq!(count, 1);
+                    send += 1;
+                }
+                assert!(
+                    send == n,
+                    "didn't send enough, thus didn't wake enough senders"
+                );
+            }
+        });
     }
 
     #[test]
@@ -500,377 +569,404 @@ mod future {
     }
 
     #[test]
-    fn send_many_values_full_channel_len_senders() {
-        send_many_values_full_channel_test(SMALL_CAP);
-    }
-
-    #[test]
-    fn send_many_values_full_channel_many_senders() {
-        send_many_values_full_channel_test(2 * SMALL_CAP);
+    fn send_many_values_full_channel_ten_senders() {
+        send_many_values_full_channel_test(10);
     }
 
     #[test]
     fn send_value_supports_polling_with_different_wakers() {
-        let (sender, mut receiver) = new_small::<usize>();
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new::<usize>(capacity);
 
-        for _ in 0..SMALL_CAP {
-            sender.try_send(123).unwrap();
-        }
+            for _ in 0..capacity {
+                sender.try_send(123).unwrap();
+            }
 
-        let (waker1, count1) = new_count_waker();
-        let (waker2, count2) = new_count_waker();
-        let mut ctx1 = task::Context::from_waker(&waker1);
-        let mut ctx2 = task::Context::from_waker(&waker2);
+            let (waker1, count1) = new_count_waker();
+            let (waker2, count2) = new_count_waker();
+            let mut ctx1 = task::Context::from_waker(&waker1);
+            let mut ctx2 = task::Context::from_waker(&waker2);
 
-        let mut future = Box::pin(sender.send(10));
-        assert_eq!(future.as_mut().poll(&mut ctx1), Poll::Pending);
-        assert_eq!(future.as_mut().poll(&mut ctx2), Poll::Pending);
+            let mut future = Box::pin(sender.send(10));
+            assert_eq!(future.as_mut().poll(&mut ctx1), Poll::Pending);
+            assert_eq!(future.as_mut().poll(&mut ctx2), Poll::Pending);
 
-        for _ in 0..SMALL_CAP {
-            assert_eq!(receiver.try_recv().unwrap(), 123);
-        }
-        drop(receiver);
+            for _ in 0..capacity {
+                assert_eq!(receiver.try_recv().unwrap(), 123);
+            }
+            drop(receiver);
 
-        assert_eq!(count1, 0);
-        assert_eq!(count2, 1);
+            assert_eq!(count1, 0);
+            assert_eq!(count2, 1);
+        });
     }
 
     #[test]
     fn recv_value() {
-        let (waker, count) = new_count_waker();
-        let (sender, mut receiver) = new_small::<usize>();
+        with_all_capacities!(|capacity| {
+            let (waker, count) = new_count_waker();
+            let (sender, mut receiver) = new::<usize>(capacity);
 
-        let mut ctx = task::Context::from_waker(&waker);
+            let mut ctx = task::Context::from_waker(&waker);
 
-        let future = receiver.recv();
-        pin_stack!(future);
+            let future = receiver.recv();
+            pin_stack!(future);
 
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
 
-        sender.try_send(10).unwrap();
-        assert_eq!(count, 1);
+            sender.try_send(10).unwrap();
+            assert_eq!(count, 1);
 
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
+        });
     }
 
     #[test]
     fn recv_value_wake_up_optimised() {
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
-        let (sender, mut receiver) = new_small::<usize>();
+        with_all_capacities!(|capacity| {
+            if capacity < 2 {
+                // Requires us to send a minimum of two values.
+                continue;
+            }
 
-        let future = receiver.recv();
-        pin_stack!(future);
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
+            let (sender, mut receiver) = new::<usize>(capacity);
 
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            let future = receiver.recv();
+            pin_stack!(future);
 
-        sender.try_send(10).unwrap();
-        assert_eq!(count, 1);
-        sender.try_send(20).unwrap();
-        assert_eq!(count, 1); // Second wake-up optimised away.
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
 
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
+            sender.try_send(10).unwrap();
+            assert_eq!(count, 1);
+            sender.try_send(20).unwrap();
+            assert_eq!(count, 1); // Second wake-up optimised away.
+
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
+        });
     }
 
     #[test]
     fn recv_value_twice() {
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
-        let (sender, mut receiver) = new_small::<usize>();
+        with_all_capacities!(|capacity| {
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
+            let (sender, mut receiver) = new::<usize>(capacity);
 
-        // Create Future and register waker (by polling).
-        let future = receiver.recv();
-        pin_stack!(future);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            // Create Future and register waker (by polling).
+            let future = receiver.recv();
+            pin_stack!(future);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
 
-        // Send value.
-        sender.try_send(10).unwrap();
-        assert_eq!(count, 1);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
+            // Send value.
+            sender.try_send(10).unwrap();
+            assert_eq!(count, 1);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
 
-        // Create second Future with and use the same waker.
-        let future = receiver.recv();
-        pin_stack!(future);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            // Create second Future with and use the same waker.
+            let future = receiver.recv();
+            pin_stack!(future);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
 
-        // Send second value.
-        sender.try_send(20).unwrap();
-        assert_eq!(count, 2);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(20)));
+            // Send second value.
+            sender.try_send(20).unwrap();
+            assert_eq!(count, 2);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(20)));
+        });
     }
 
     #[test]
     fn recv_value_twice_senders_dropped() {
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
-        let (sender, mut receiver) = new_small::<usize>();
+        with_all_capacities!(|capacity| {
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
+            let (sender, mut receiver) = new::<usize>(capacity);
 
-        // Create Future and register waker (by polling).
-        let future = receiver.recv();
-        pin_stack!(future);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            // Create Future and register waker (by polling).
+            let future = receiver.recv();
+            pin_stack!(future);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
 
-        // Send value.
-        sender.try_send(10).unwrap();
-        assert_eq!(count, 1);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
+            // Send value.
+            sender.try_send(10).unwrap();
+            assert_eq!(count, 1);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
 
-        // Create second Future with and use the same waker.
-        let future = receiver.recv();
-        pin_stack!(future);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            // Create second Future with and use the same waker.
+            let future = receiver.recv();
+            pin_stack!(future);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
 
-        // Dropping the second should wake up the receiver.
-        drop(sender);
-        assert_eq!(count, 2);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(None));
+            // Dropping the second should wake up the receiver.
+            drop(sender);
+            assert_eq!(count, 2);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(None));
+        });
     }
 
     #[test]
     fn recv_value_empty() {
-        let (waker, count) = new_count_waker();
+        with_all_capacities!(|capacity| {
+            let (waker, count) = new_count_waker();
+            let (sender, mut receiver) = new::<usize>(capacity);
 
-        let (sender, mut receiver) = new_small::<usize>();
+            let mut ctx = task::Context::from_waker(&waker);
 
-        let mut ctx = task::Context::from_waker(&waker);
-
-        let future = receiver.recv();
-        pin_stack!(future);
-
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-        assert_eq!(count, 0);
-
-        sender.try_send(10).unwrap();
-
-        assert_eq!(count, 1);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
-    }
-
-    #[test]
-    fn recv_value_all_senders_disconnected() {
-        let (waker, count) = new_count_waker();
-
-        let (sender, mut receiver) = new_small::<usize>();
-
-        let mut ctx = task::Context::from_waker(&waker);
-
-        let future = receiver.recv();
-        pin_stack!(future);
-
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-
-        // Dropping the last sender should notify the receiver.
-        drop(sender);
-        assert_eq!(count, 1);
-
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(None));
-    }
-
-    #[test]
-    fn recv_value_all_senders_disconnected_not_empty() {
-        let (waker, count) = new_count_waker();
-
-        let (sender, mut receiver) = new_small::<usize>();
-
-        let mut ctx = task::Context::from_waker(&waker);
-
-        let future = receiver.recv();
-        pin_stack!(future);
-
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-
-        // Sending and dropping the last sender should wake the receiver.
-        sender.try_send(10).unwrap();
-        assert_eq!(count, 1);
-        drop(sender);
-        assert_eq!(count, 1); // Wake-up optimised away.
-
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
-        let mut future = receiver.recv();
-        assert_eq!(Pin::new(&mut future).poll(&mut ctx), Poll::Ready(None));
-    }
-
-    #[test]
-    fn recv_value_all_senders_disconnected_cloned_sender() {
-        let (waker, count) = new_count_waker();
-
-        let (sender, mut receiver) = new_small::<usize>();
-        let sender2 = sender.clone();
-
-        let mut ctx = task::Context::from_waker(&waker);
-
-        let future = receiver.recv();
-        pin_stack!(future);
-
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-
-        // Only dropping the last sender should wake the receiver.
-        drop(sender);
-        assert_eq!(count, 0);
-        drop(sender2);
-        assert_eq!(count, 1);
-
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(None));
-    }
-
-    #[test]
-    fn recv_value_only_wake_if_polled() {
-        let (waker, count) = new_count_waker();
-
-        let (sender, mut receiver) = new_small::<usize>();
-
-        let mut ctx = task::Context::from_waker(&waker);
-
-        let future = receiver.recv();
-        pin_stack!(future);
-
-        drop(sender);
-        // `RecvValue` isn't polled yet, so we shouldn't receive a wake-up
-        // notification.
-        assert_eq!(count, 0);
-
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(None));
-    }
-
-    #[test]
-    fn registered_receiver_waker() {
-        let (sender, mut receiver) = new_small::<usize>();
-
-        let (waker, count) = new_count_waker();
-        receiver.register_waker(&waker);
-
-        assert_eq!(count, 0);
-        assert_eq!(sender.try_send(10), Ok(()));
-        assert_eq!(count, 1);
-        assert_eq!(receiver.try_recv(), Ok(10));
-    }
-
-    #[test]
-    fn forget_send_value() {
-        let (sender, mut receiver) = new_small::<usize>();
-
-        // Fill the channel.
-        for n in 0..SMALL_CAP {
-            sender.try_send(n).unwrap();
-        }
-
-        // Create the `SendValue` future and poll it once to register the waker.
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
-        let future = sender.send(10);
-        pin_stack!(future);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-        std::mem::forget(future);
-
-        assert_eq!(count, 0);
-        assert_eq!(receiver.try_recv(), Ok(0));
-        assert_eq!(count, 1);
-    }
-
-    #[test]
-    fn sender_join() {
-        let (sender, receiver) = new_small::<usize>();
-
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
-
-        let future = sender.join();
-        pin_stack!(future);
-
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-        assert_eq!(count, 0);
-
-        drop(receiver);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(()));
-        assert_eq!(count, 1);
-    }
-
-    #[test]
-    fn sender_join_drop_before_waker_register() {
-        let (sender, receiver) = new_small::<usize>();
-        drop(receiver);
-
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
-
-        let future = sender.join();
-        pin_stack!(future);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(()));
-        assert_eq!(count, 0);
-    }
-
-    #[test]
-    fn sender_join_dont_register_waker_twice() {
-        let (sender, receiver) = new_small::<usize>();
-
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
-
-        let future = sender.join();
-        pin_stack!(future);
-
-        // Poll twice.
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-        assert_eq!(count, 0);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
-        assert_eq!(count, 0);
-
-        drop(receiver);
-        assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(()));
-        assert_eq!(count, 1);
-    }
-
-    #[test]
-    fn sender_join_poll_with_different_wakers() {
-        let (sender, receiver) = new_small::<usize>();
-
-        let (waker, count1) = new_count_waker();
-        let mut ctx1 = task::Context::from_waker(&waker);
-        let (waker, count2) = new_count_waker();
-        let mut ctx2 = task::Context::from_waker(&waker);
-
-        let future = sender.join();
-        pin_stack!(future);
-
-        assert_eq!(future.as_mut().poll(&mut ctx1), Poll::Pending);
-        assert_eq!(count1, 0);
-        // Poll with a different waker.
-        assert_eq!(future.as_mut().poll(&mut ctx2), Poll::Pending);
-        assert_eq!(count2, 0);
-
-        drop(receiver);
-        assert_eq!(future.as_mut().poll(&mut ctx2), Poll::Ready(()));
-        assert_eq!(count1, 0);
-        assert_eq!(count2, 1);
-    }
-
-    #[test]
-    fn sender_join_no_wakeup_after_drop() {
-        let (sender, receiver) = new_small::<usize>();
-
-        let (waker, count) = new_count_waker();
-        let mut ctx = task::Context::from_waker(&waker);
-
-        {
-            // NOTE: putting `future` in a code block to ensure it's dropped.
-            let future = Box::pin(sender.join());
+            let future = receiver.recv();
             pin_stack!(future);
 
             assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
             assert_eq!(count, 0);
-        }
 
-        drop(receiver);
-        assert_eq!(count, 0);
+            sender.try_send(10).unwrap();
+
+            assert_eq!(count, 1);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
+        });
+    }
+
+    #[test]
+    fn recv_value_all_senders_disconnected() {
+        with_all_capacities!(|capacity| {
+            let (waker, count) = new_count_waker();
+            let (sender, mut receiver) = new::<usize>(capacity);
+
+            let mut ctx = task::Context::from_waker(&waker);
+
+            let future = receiver.recv();
+            pin_stack!(future);
+
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+
+            // Dropping the last sender should notify the receiver.
+            drop(sender);
+            assert_eq!(count, 1);
+
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(None));
+        });
+    }
+
+    #[test]
+    fn recv_value_all_senders_disconnected_not_empty() {
+        with_all_capacities!(|capacity| {
+            let (waker, count) = new_count_waker();
+            let (sender, mut receiver) = new::<usize>(capacity);
+
+            let mut ctx = task::Context::from_waker(&waker);
+
+            let future = receiver.recv();
+            pin_stack!(future);
+
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+
+            // Sending and dropping the last sender should wake the receiver.
+            sender.try_send(10).unwrap();
+            assert_eq!(count, 1);
+            drop(sender);
+            assert_eq!(count, 1); // Wake-up optimised away.
+
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(Some(10)));
+            let mut future = receiver.recv();
+            assert_eq!(Pin::new(&mut future).poll(&mut ctx), Poll::Ready(None));
+        });
+    }
+
+    #[test]
+    fn recv_value_all_senders_disconnected_cloned_sender() {
+        with_all_capacities!(|capacity| {
+            let (waker, count) = new_count_waker();
+            let (sender, mut receiver) = new::<usize>(capacity);
+            let sender2 = sender.clone();
+
+            let mut ctx = task::Context::from_waker(&waker);
+
+            let future = receiver.recv();
+            pin_stack!(future);
+
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+
+            // Only dropping the last sender should wake the receiver.
+            drop(sender);
+            assert_eq!(count, 0);
+            drop(sender2);
+            assert_eq!(count, 1);
+
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(None));
+        });
+    }
+
+    #[test]
+    fn recv_value_only_wake_if_polled() {
+        with_all_capacities!(|capacity| {
+            let (waker, count) = new_count_waker();
+            let (sender, mut receiver) = new::<usize>(capacity);
+
+            let mut ctx = task::Context::from_waker(&waker);
+
+            let future = receiver.recv();
+            pin_stack!(future);
+
+            drop(sender);
+            // `RecvValue` isn't polled yet, so we shouldn't receive a wake-up
+            // notification.
+            assert_eq!(count, 0);
+
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(None));
+        });
+    }
+
+    #[test]
+    fn registered_receiver_waker() {
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new::<usize>(capacity);
+
+            let (waker, count) = new_count_waker();
+            receiver.register_waker(&waker);
+
+            assert_eq!(count, 0);
+            assert_eq!(sender.try_send(10), Ok(()));
+            assert_eq!(count, 1);
+            assert_eq!(receiver.try_recv(), Ok(10));
+        });
+    }
+
+    #[test]
+    fn forget_send_value() {
+        with_all_capacities!(|capacity| {
+            let (sender, mut receiver) = new::<usize>(capacity);
+
+            // Fill the channel.
+            for n in 0..capacity {
+                sender.try_send(n).unwrap();
+            }
+
+            // Create the `SendValue` future and poll it once to register the waker.
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
+            let future = sender.send(10);
+            pin_stack!(future);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            std::mem::forget(future);
+            assert_eq!(receiver.try_recv(), Ok(0));
+            assert_eq!(count, 1);
+        });
+    }
+
+    #[test]
+    fn sender_join() {
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new::<usize>(capacity);
+
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
+
+            let future = sender.join();
+            pin_stack!(future);
+
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            assert_eq!(count, 0);
+
+            drop(receiver);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(()));
+            assert_eq!(count, 1);
+        });
+    }
+
+    #[test]
+    fn sender_join_drop_before_waker_register() {
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new::<usize>(capacity);
+            drop(receiver);
+
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
+
+            let future = sender.join();
+            pin_stack!(future);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(()));
+            assert_eq!(count, 0);
+        });
+    }
+
+    #[test]
+    fn sender_join_dont_register_waker_twice() {
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new::<usize>(capacity);
+
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
+
+            let future = sender.join();
+            pin_stack!(future);
+
+            // Poll twice.
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            assert_eq!(count, 0);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+            assert_eq!(count, 0);
+
+            drop(receiver);
+            assert_eq!(future.as_mut().poll(&mut ctx), Poll::Ready(()));
+            assert_eq!(count, 1);
+        });
+    }
+
+    #[test]
+    fn sender_join_poll_with_different_wakers() {
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new::<usize>(capacity);
+
+            let (waker, count1) = new_count_waker();
+            let mut ctx1 = task::Context::from_waker(&waker);
+            let (waker, count2) = new_count_waker();
+            let mut ctx2 = task::Context::from_waker(&waker);
+
+            let future = sender.join();
+            pin_stack!(future);
+
+            assert_eq!(future.as_mut().poll(&mut ctx1), Poll::Pending);
+            assert_eq!(count1, 0);
+            // Poll with a different waker.
+            assert_eq!(future.as_mut().poll(&mut ctx2), Poll::Pending);
+            assert_eq!(count2, 0);
+
+            drop(receiver);
+            assert_eq!(future.as_mut().poll(&mut ctx2), Poll::Ready(()));
+            assert_eq!(count1, 0);
+            assert_eq!(count2, 1);
+        });
+    }
+
+    #[test]
+    fn sender_join_no_wakeup_after_drop() {
+        with_all_capacities!(|capacity| {
+            let (sender, receiver) = new::<usize>(capacity);
+
+            let (waker, count) = new_count_waker();
+            let mut ctx = task::Context::from_waker(&waker);
+
+            {
+                // NOTE: putting `future` in a code block to ensure it's dropped.
+                let future = Box::pin(sender.join());
+                pin_stack!(future);
+
+                assert_eq!(future.as_mut().poll(&mut ctx), Poll::Pending);
+                assert_eq!(count, 0);
+            }
+
+            drop(receiver);
+            assert_eq!(count, 0);
+        });
     }
 }
 
 mod manager {
-    use heph_inbox::{Manager, ReceiverConnected};
+    use heph_inbox::{self as inbox, Manager, ReceiverConnected};
 
     #[test]
     fn new_sender() {
-        let (manager, sender1, mut receiver) = Manager::<usize>::new_small_channel();
+        let (manager, sender1, mut receiver) = Manager::<usize>::new_channel(2);
         let sender2 = manager.new_sender();
 
         sender1.try_send(123).unwrap();
@@ -882,7 +978,7 @@ mod manager {
 
     #[test]
     fn new_receiver() {
-        let (manager, sender, receiver) = Manager::<usize>::new_small_channel();
+        let (manager, sender, receiver) = Manager::<usize>::new_channel(3);
         sender.try_send(123).unwrap();
 
         drop(receiver);
@@ -896,21 +992,23 @@ mod manager {
 
     #[test]
     fn new_receiver_already_exists() {
-        let (manager, _sender, _receiver) = Manager::<usize>::new_small_channel();
+        let (manager, _sender, _receiver) = Manager::<usize>::new_channel(1);
         assert_eq!(manager.new_receiver().unwrap_err(), ReceiverConnected);
     }
 
     #[test]
     fn sending_and_receiving_value() {
-        let (manager, sender, mut receiver) = Manager::<usize>::new_small_channel();
-        sender.try_send(123).unwrap();
-        assert_eq!(receiver.try_recv().unwrap(), 123);
-        drop(manager);
+        with_all_capacities!(|capacity| {
+            let (manager, sender, mut receiver) = Manager::<usize>::new_channel(capacity);
+            sender.try_send(123).unwrap();
+            assert_eq!(receiver.try_recv().unwrap(), 123);
+            drop(manager);
+        });
     }
 
     #[test]
     fn sender_is_connected() {
-        let (manager, sender, receiver) = Manager::<usize>::new_small_channel();
+        let (manager, sender, receiver) = Manager::<usize>::new_channel(4);
         assert!(sender.is_connected());
         drop(receiver);
         // Manager is still alive.
@@ -921,14 +1019,14 @@ mod manager {
 
     #[test]
     fn receiver_is_connected() {
-        let (manager, sender, receiver) = Manager::<usize>::new_small_channel();
+        let (manager, sender, receiver) = Manager::<usize>::new_channel(5);
         assert!(receiver.is_connected());
         drop(manager);
         assert!(receiver.is_connected());
         drop(sender);
         assert!(!receiver.is_connected());
 
-        let (manager, sender, receiver) = Manager::<usize>::new_small_channel();
+        let (manager, sender, receiver) = Manager::<usize>::new_channel(6);
         assert!(receiver.is_connected());
         drop(sender);
         assert!(!receiver.is_connected());
@@ -960,9 +1058,9 @@ mod manager {
 
     #[test]
     fn same_channel() {
-        let (manager1, sender1a, _) = Manager::<usize>::new_small_channel();
+        let (manager1, sender1a, _) = Manager::<usize>::new_channel(1);
         let sender1b = manager1.new_sender();
-        let (manager2, sender2a, _) = Manager::<usize>::new_small_channel();
+        let (manager2, sender2a, _) = Manager::<usize>::new_channel(1);
         let sender2b = manager2.new_sender();
 
         assert!(sender1a.same_channel(&sender1a));
@@ -986,9 +1084,9 @@ mod manager {
 
     #[test]
     fn sends_to() {
-        let (manager1, sender1a, receiver1) = Manager::<usize>::new_small_channel();
+        let (manager1, sender1a, receiver1) = Manager::<usize>::new_channel(1);
         let sender1b = manager1.new_sender();
-        let (manager2, sender2a, receiver2) = Manager::<usize>::new_small_channel();
+        let (manager2, sender2a, receiver2) = Manager::<usize>::new_channel(1);
         let sender2b = manager2.new_sender();
 
         assert!(sender1a.sends_to(&receiver1));

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,28 +1,35 @@
 //! Regression tests.
 
-use heph_inbox::new_small;
+#![feature(once_cell)]
+
 use heph_inbox::oneshot::{self, new_oneshot};
+use heph_inbox::{self as inbox, new};
+
+#[macro_use]
+mod util;
 
 #[test]
 fn cyclic_drop_dependency_with_oneshot_channel() {
-    let (sender, receiver) = new_small();
-    let (one_send, mut one_recv) = new_oneshot::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new(capacity);
+        let (one_send, mut one_recv) = new_oneshot::<usize>();
 
-    // Put `oneshot::Sender` in the channel.
-    sender.try_send(one_send).unwrap();
+        // Put `oneshot::Sender` in the channel.
+        sender.try_send(one_send).unwrap();
 
-    // Dropping the receiver should also drop the `oneshot::Sender` we send
-    // above.
-    drop(receiver);
-    // This needs to work in case we would call `oneshot::Receiver::recv` here.
-    // If we didn't empty the channel on dropping the `Receiver` this would
-    // return a `NoValue` error.
-    assert_eq!(
-        one_recv.try_recv().unwrap_err(),
-        oneshot::RecvError::Disconnected
-    );
+        // Dropping the receiver should also drop the `oneshot::Sender` we send
+        // above.
+        drop(receiver);
+        // This needs to work in case we would call `oneshot::Receiver::recv` here.
+        // If we didn't empty the channel on dropping the `Receiver` this would
+        // return a `NoValue` error.
+        assert_eq!(
+            one_recv.try_recv().unwrap_err(),
+            oneshot::RecvError::Disconnected
+        );
 
-    drop(one_recv);
-    // This needs to live until now.
-    drop(sender);
+        drop(one_recv);
+        // This needs to live until now.
+        drop(sender);
+    });
 }

--- a/tests/threaded.rs
+++ b/tests/threaded.rs
@@ -5,7 +5,7 @@
 use std::thread;
 use std::time::Duration;
 
-use heph_inbox::{new_small, Manager, RecvError, SendError};
+use heph_inbox::{self as inbox, new, Manager, RecvError, SendError};
 
 #[macro_use]
 mod util;
@@ -13,111 +13,123 @@ mod util;
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't finish.
 fn send_single_value() {
-    let (sender, mut receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            expect_send!(sender, 1);
-        },
-        {
-            expect_recv!(receiver, 1);
-        }
-    );
+        start_threads!(
+            {
+                expect_send!(sender, 1);
+            },
+            {
+                expect_recv!(receiver, 1);
+            }
+        );
+    });
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't finish.
 fn zero_sized_types() {
-    let (sender, mut receiver) = new_small();
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new(capacity);
 
-    start_threads!(
-        {
-            expect_send!(sender, ());
-        },
-        {
-            expect_recv!(receiver, ());
-        }
-    );
+        start_threads!(
+            {
+                expect_send!(sender, ());
+            },
+            {
+                expect_recv!(receiver, ());
+            }
+        );
+    });
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't finish.
 fn receive_no_sender() {
-    let (sender, mut receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, mut receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            drop(sender);
-        },
-        {
-            r#loop! {
-                match receiver.try_recv() {
-                    Ok(..) => panic!("unexpected receive of value"),
-                    Err(RecvError::Empty) => {} // Try again.
-                    Err(RecvError::Disconnected) => break,
+        start_threads!(
+            {
+                drop(sender);
+            },
+            {
+                r#loop! {
+                    match receiver.try_recv() {
+                        Ok(..) => panic!("unexpected receive of value"),
+                        Err(RecvError::Empty) => {} // Try again.
+                        Err(RecvError::Disconnected) => break,
+                    }
                 }
             }
-        }
-    );
+        );
+    });
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't support `sleep`.
 fn send_no_receiver() {
-    let (sender, receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            thread::sleep(Duration::from_millis(1));
-            r#loop! {
-                match sender.try_send(1) {
-                    Ok(()) => {} // Try again.
-                    Err(SendError::Full(..)) => panic!("too slow!"),
-                    Err(SendError::Disconnected(..)) => break,
+        start_threads!(
+            {
+                thread::sleep(Duration::from_millis(1));
+                r#loop! {
+                    match sender.try_send(1) {
+                        Ok(()) => {} // Try again.
+                        Err(SendError::Full(..)) => panic!("too slow!"),
+                        Err(SendError::Disconnected(..)) => break,
+                    }
                 }
+            },
+            {
+                drop(receiver);
             }
-        },
-        {
-            drop(receiver);
-        }
-    );
+        );
+    });
 }
 
 #[test]
 fn sender_is_connected() {
-    let (sender, receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            r#loop! {
-                if !sender.is_connected() {
-                    break;
+        start_threads!(
+            {
+                r#loop! {
+                    if !sender.is_connected() {
+                        break;
+                    }
                 }
+            },
+            {
+                drop(receiver);
             }
-        },
-        {
-            drop(receiver);
-        }
-    );
+        );
+    });
 }
 
 #[test]
 #[cfg_attr(miri, ignore)] // Doesn't finish.
 fn receiver_is_connected() {
-    let (sender, receiver) = new_small::<usize>();
+    with_all_capacities!(|capacity| {
+        let (sender, receiver) = new::<usize>(capacity);
 
-    start_threads!(
-        {
-            drop(sender);
-        },
-        {
-            r#loop! {
-                if !receiver.is_connected() {
-                    break;
+        start_threads!(
+            {
+                drop(sender);
+            },
+            {
+                r#loop! {
+                    if !receiver.is_connected() {
+                        break;
+                    }
                 }
             }
-        }
-    );
+        );
+    });
 }
 
 #[test]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -9,9 +9,6 @@ use std::sync::{Arc, Mutex};
 use std::task::{self, Wake};
 use std::thread;
 
-// NOTE: keep in sync with the actual capacity.
-pub const SMALL_CAP: usize = 8;
-
 pub fn assert_send<T: Send>() {}
 pub fn assert_sync<T: Sync>() {}
 
@@ -211,6 +208,19 @@ macro_rules! expect_recv {
                 Err(heph_inbox::RecvError::Empty) => {} // Try again.
                 Err(err) => panic!("unexpected error receiving: {}", err),
             }
+        }
+    }};
+}
+
+/// Run a test with all possible capacities.
+macro_rules! with_all_capacities {
+    (|$capacity: ident| $test: block) => {{
+        #[cfg(not(feature = "stress_testing"))]
+        let iter = [inbox::MIN_CAP, 8, inbox::MAX_CAP].iter().copied();
+        #[cfg(feature = "stress_testing")]
+        let iter = inbox::MIN_CAP..=inbox::MAX_CAP;
+        for $capacity in iter {
+            $test
         }
     }};
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -156,7 +156,6 @@ macro_rules! start_threads {
         drop(thread_guard);
 
         if !errors.is_empty() {
-            #[track_caller]
             panic!("thread failed, error(s): {:?}", errors);
         }
     }};


### PR DESCRIPTION
... Well arbitrary as long it's not longer then 29 messages.

Done by changing Channel's `slots` to be a slice

Allocating the Channel becomes a bit more complex as we need to manually
the layout for it and can't use the convenience of the Box type.

This also has the side effect of making the pointers in Sender, Receiver
and Manager a "fat" pointer. This means it will contain the regular
pointer and a length attribute, taking up (2 x 8) 16 bytes on 64bit.

This increases the size of Sender, Receiver, Manager from 8 to 16 bytes,
SendValue from 32 to 40 bytes and Join from 24 to 32 bytes.

If this size increase becomes a problem, or if we ever want to decrease
the memory usage we can change the fat pointer into a regular pointer
again and using some bits to indicate the length of the channel. For
examples if we have four different capacities, it can be encoded into
just 2 bits. These two bits can ORed with the regular pointer and be
received later.

The upside of such an approach would be that the size is reduced from 16
to 8 bytes. The downside is that on each access to the channel the
reference has to be prepared by unpacking the length from the pointer.
And ensuring the length is correct at all times is an additional
maintenance burden.

Introduces `new` function (also on `Manager`)

Allows the creation of an user specified capacity bounded channel. The
current implementation is limited to a capacity in the range 1..=29.

This limitation is because of the size of the `status` in the Channel.
As each slot needs two bits for its status and we need enough bits for
the receiver position the current limit is 29. The following must hold
true, where $n is the capacity of the channel:
2 ^ (64 - ($N * 2)) >= $N.

Finally this changes the tests to use all possible capacities

This touches nearly all tests, using the new with_all_capacities! macro
to run a test with all capacities possible.

With the 'stress_testing' feature enabled this will actually run all
capacities, with it disabled it will only run three capacities (minimum,
maximum and the small capacity) for performance.

For the stress_sending_fill test it only uses capacities that are a
power of two. The problem is the wrap around of the receiver position
with capacities that are **not** a power of two.

For example taking a capacity of 5. The maximum receiver position is 63
(6 bits), which is index 3. The next value will be 0 (with wrap around),
which is index 0. This means we've skipped index 4. The crate doesn't
guaranteed FIFO ordering so it's fine, but the test assumes it.

Closes issue #4.