### PR TITLE
Add user defined metadata to the channel

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -51,7 +51,7 @@ fn new_count_waker() -> (task::Waker, AwokenCount) {
 
 #[test]
 fn size_assertions() {
-    let channel = unsafe { Box::from_raw(Channel::<()>::new(1).as_ptr()) };
+    let channel = unsafe { Box::from_raw(Channel::<(), ()>::new(1, ()).as_ptr()) };
     assert_eq!(size_of_val(&**channel), 112);
     assert_eq!(size_of::<Sender<()>>(), 16);
     assert_eq!(size_of::<Receiver<()>>(), 16);
@@ -208,8 +208,8 @@ fn test_receiver_pos() {
     }
 }
 
-fn test_channel() -> Box<Channel<usize>> {
-    unsafe { Box::from_raw(Channel::new(SMALL_CAP).as_ptr()) }
+fn test_channel() -> Box<Channel<usize, ()>> {
+    unsafe { Box::from_raw(Channel::new(SMALL_CAP, ()).as_ptr()) }
 }
 
 #[test]

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -382,6 +382,13 @@ fn receiver_new_sender() {
     });
 }
 
+#[test]
+fn with_metadata() {
+    let (sender, receiver) = inbox::new_with_metadata::<usize, _>(1, "abc");
+    assert_eq!(*sender.metadata(), "abc");
+    assert_eq!(*receiver.metadata(), "abc");
+}
+
 mod future {
     //! Tests for the `Future` implementations.
 
@@ -1098,5 +1105,13 @@ mod manager {
         assert!(sender2a.sends_to(&receiver2));
         assert!(!sender2b.sends_to(&receiver1));
         assert!(sender2b.sends_to(&receiver2));
+    }
+
+    #[test]
+    fn with_metadata() {
+        let (manager, sender, receiver) = Manager::<usize, _>::new_channel_with_metadata(1, "abc");
+        assert_eq!(*sender.metadata(), "abc");
+        assert_eq!(*receiver.metadata(), "abc");
+        assert_eq!(*manager.metadata(), "abc");
     }
 }


### PR DESCRIPTION
This adds the following functions:
 * `new_with_metadata`
 * `Manager::new_with_metadata`
 * `Sender::metadata`
 * `Receiver::metadata`
 
Shouldn't be a breaking change as the default type is set to `()`.