### PR TITLE
Add Receiver::(try_)peek

### DIFF
--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -212,6 +212,22 @@ macro_rules! expect_recv {
     }};
 }
 
+/// Loop until a value is peeked.
+macro_rules! expect_peek {
+    ($receiver: expr, $expected: expr) => {{
+        r#loop! {
+            match $receiver.try_peek() {
+                Ok(msg) => {
+                    assert_eq!(*msg, $expected);
+                    break;
+                }
+                Err(heph_inbox::RecvError::Empty) => {} // Try again.
+                Err(err) => panic!("unexpected error receiving: {}", err),
+            }
+        }
+    }};
+}
+
 /// Run a test with all possible capacities.
 macro_rules! with_all_capacities {
     (|$capacity: ident| $test: block) => {{


### PR DESCRIPTION
Allows the user to peek at the next available message in the inbox. The
API is similar to that of the try_recv and recv methods, but return &T
(instead of T).

Both methods need mutable access for peeking because of the waker
situation, which only supports a single waker for the receiver. At the
moment I don't think it's worth it to make the reiceiver more complex
simply to support immutable reference for peeking.

Closes #33