### PR TITLE
Replace parking_lot with locks in std lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,3 @@ edition       = "2018"
 [features]
 # Enables some tests that take a long to run.
 stress_testing = []
-
-[dependencies]
-parking_lot = { version = "0.11.0", default-features = false }


### PR DESCRIPTION
The locks in the standard library have seen a number of improvements in
recent releases.

Closes #37.